### PR TITLE
Fill in problem

### DIFF
--- a/bin/latex.py
+++ b/bin/latex.py
@@ -189,9 +189,10 @@ def build_contest_pdf(contest, problems, solutions=False, web=False):
     ensure_symlink(builddir / 'bapc.cls', config.tools_root / 'latex/bapc.cls')
     ensure_symlink(builddir / 'images', config.tools_root / 'latex/images')
     ensure_symlink(builddir / main_file, config.tools_root / 'latex' / main_file)
+
     config_data = util.read_yaml(Path('contest.yaml'))
-    config_data['testsession'] = '\\testsession' if hasattr(
-        config_data, 'testsession') and config_data['testsession'] else ''
+    config_data['testsession'] = '\\testsession' if config_data.get('testsession') else ''
+
     util.copy_and_substitute(config.tools_root / 'latex/contest-data.tex',
                              builddir / 'contest_data.tex', config_data)
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -1805,9 +1805,8 @@ def new_problem():
         validation = ask_variable('validation', 'default')
 
     # Read settings from the contest-level yaml file.
-    variables = {}
-    for k, v in util.read_yaml(Path('contest.yaml')).items():
-        variables[k] = v
+    variables = util.read_yaml(Path('contest.yaml'))
+
     for k, v in {
             'problemname': problemname,
             'dirname': dirname,
@@ -1815,9 +1814,6 @@ def new_problem():
             'validation': validation
     }.items():
         variables[k] = v
-
-    for key in variables:
-        print(key, ' -> ', variables[key])
 
     # Copy tree from the skel directory, next to the contest, if it is found.
     skeldir = config.tools_root / 'skel/problem'

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -1786,9 +1786,8 @@ def new_contest(name):
     license = ask_variable('license', 'cc by-sa')
     rights_owner = ask_variable('rights owner', 'author')
 
-    shutil.copytree(config.tools_root / 'skel/contest', dirname, symlinks=True)
-
-    util.substitute_dir_variables(Path(dirname), locals())
+    skeldir = config.tools_root / 'skel/contest'
+    util.copytree_and_substitute(skeldir, Path(dirname), locals(), exist_ok=False)
 
 
 def new_problem():
@@ -1825,10 +1824,8 @@ def new_problem():
     if Path('skel/problem').is_dir(): skeldir = Path('skel/problem')
     if Path('../skel/problem').is_dir(): skeldir = Path('../skel/problem')
     print(f'Copying {skeldir} to {dirname}.')
-    shutil.copytree(skeldir, dirname, symlinks=True)
 
-    util.substitute_dir_variables(Path(dirname), variables)
-
+    util.copytree_and_substitute(skeldir, Path(dirname), variables, exist_ok=True)
 
 def new_cfp_problem(name):
     shutil.copytree(config.tools_root / 'skel/problem_cfp', name, symlinks=True)

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -1779,8 +1779,7 @@ def new_contest(name):
     subtitle = ask_variable('subtitle', '')
     dirname = ask_variable('dirname', alpha_num(title))
     author = ask_variable('author', f'The {title} jury')
-    testsession = ('% '
-                   if ask_variable('testsession?', 'n (y/n)')[0] == 'n' else '') + '\\testsession'
+    testsession = ask_variable('testsession?', 'n (y/n)')[0] != 'n' # boolean
     year = ask_variable('year', str(datetime.datetime.now().year))
     source = ask_variable('source', title)
     source_url = ask_variable('source url', '')

--- a/bin/util.py
+++ b/bin/util.py
@@ -232,9 +232,15 @@ def substitute(data, variables):
 
 
 def copy_and_substitute(inpath, outpath, variables):
-    data = inpath.read_text()
+    try:
+        data = inpath.read_text()
+    except UnicodeDecodeError:
+        # skip this file
+        warn(f'File "{inpath}" has no unicode encoding.')
+        return
     data = substitute(data, variables)
-    if outpath.is_symlink(): outpath.unlink()
+    if outpath.is_symlink():
+        outpath.unlink()
     outpath.write_text(data)
 
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -254,6 +254,41 @@ def substitute_dir_variables(dirname, variables):
             substitute_file_variables(path, variables)
 
 
+# copies a directory recursively and substitutes {%key%} by their value in text files
+# reference: https://docs.python.org/3/library/shutil.html#copytree-example
+def copytree_and_substitute(src, dst, variables, exist_ok=True):
+    names = os.listdir(src)
+    os.makedirs(dst, exist_ok=exist_ok)
+    errors = []
+    for name in names:
+        try:
+            srcFile = src / name
+            dstFile = dst / name
+
+            if (os.path.isdir(srcFile)):
+                copytree_and_substitute(srcFile, dstFile, variables, exist_ok)
+            elif (dstFile.exists()):
+                warn(f'File "{dstFile}" already exists, skipping...')
+                continue
+            else:
+                try:
+                    data = srcFile.read_text()
+                    data = substitute(data, variables)
+                    dstFile.write_text(data)
+                except UnicodeDecodeError:
+                    # skip this file
+                    warn(f'File "{srcFile}" has no unicode encoding.')
+                    dstFile.write_bytes(srcFile.read_bytes())
+        except OSError as why:
+            errors.append((srcFile, dstFile, str(why)))
+        # catch the Error from the recursive copytree so that we can
+        # continue with other files
+        except Error as err:
+            errors.extend(err.args[0])
+    if errors:
+        raise Error(errors)
+
+
 def crop_output(output):
     if config.args.noerror: return None
     if config.args.error: return output


### PR DESCRIPTION
Basically a rewrite of the shutil.copytree, to allow to create a new problem when some of the files do already exist (in case of a CFP), so adding all the submissions directories, etc. goes automatically without overwriting existing files.