### PR TITLE
Detect mainclass as the basename, not full path

### DIFF
--- a/bin/tools.py
+++ b/bin/tools.py
@@ -279,8 +279,8 @@ def build(path):
         'files': ''.join(str(f) for f in files),
         'binary': str(runfile),
         'mainfile': str(mainfile),
-        'mainclass': str(Path(mainfile).with_suffix('')),
-        'Mainclass': str(Path(mainfile).with_suffix('')).capitalize(),
+        'mainclass': str(Path(mainfile).with_suffix('').name),
+        'Mainclass': str(Path(mainfile).with_suffix('').name).capitalize(),
         'memlim': util.get_memory_limit() // 1000000
     }
 


### PR DESCRIPTION
Before this change mainclass would be generated as /tmp/something/class
which is wrong because the mainclass is almost always going to be the
same as the filename for the two languages which care about this (java
and kotlin).

This allows running java programs with BAPCtools.