### PR TITLE
Fix width of parboxes in interactive samples

### DIFF
--- a/latex/bapc.cls
+++ b/latex/bapc.cls
@@ -222,7 +222,7 @@
 	\ttfamily
 	\frenchspacing% to prevent extra spaces after punctuation. https://tex.stackexchange.com/q/118455/43242
 	\hfill\framebox[0.55\textwidth][l]{%
-		\parbox[t]{\textwidth}{
+		\parbox[t]{\dimexpr0.55\textwidth-2\fboxsep-2\fboxrule\relax}{
 			\vspace{-.4em}%
 			\strut%
 			\BODY
@@ -239,7 +239,7 @@
 	\ttfamily
 	\frenchspacing% to prevent extra spaces after punctuation. https://tex.stackexchange.com/q/118455/43242
 	\framebox[0.55\textwidth][l]{%
-		\parbox[t]{\textwidth}{
+		\parbox[t]{\dimexpr0.55\textwidth-2\fboxsep-2\fboxrule\relax}{
 			\vspace{-.4em}%
 			\strut%
 			\BODY


### PR DESCRIPTION
When the `\parbox` has a width of `\textwidth`, that means that the text can spread over the entire page width, because `\textwidth` is apparently not adapted to the width of the wrapping `\framebox`.
Now, the width of the text inside the `\parbox` is fixed to the same width of the `\framebox`, minus two times the width of the padding + border of the `\framebox`.

<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/9739541/85951355-f49bb480-b962-11ea-8e33-495c73cb2e02.png)
</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/9739541/85951367-0ed59280-b963-11ea-99f5-b6c3a853a8ca.png)
</details>