### PR TITLE
Remove symlinks from PDF generation

### DIFF
--- a/bin/latex.py
+++ b/bin/latex.py
@@ -160,8 +160,7 @@ def build_problem_pdf(problem):
         env = os.environ.copy()
         env["TEXINPUTS"] = str(config.tools_root / 'latex') + ';';
         ret = util.exec_command(
-            PDFLATEX + ['-aux-directory', builddir,
-                        '-output-directory', problem.path.absolute(),
+            PDFLATEX + ['-output-directory', builddir,
                         builddir / 'problem.tex'],
             0,
             False,
@@ -173,8 +172,9 @@ def build_problem_pdf(problem):
             print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
             return False
 
-    # show output filename
+    # link the output pdf
     output_pdf = problem.path / 'problem.pdf'
+    ensure_symlink(output_pdf, builddir / 'problem.pdf', True)
 
     print(f'{cc.green}Pdf written to {output_pdf}{cc.reset}')
     return True
@@ -254,8 +254,7 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
         env = os.environ.copy()
         env["TEXINPUTS"] = str(config.tools_root / 'latex') + ';';
         ret = util.exec_command(
-            PDFLATEX + ['-aux-directory', builddir,
-                        '-output-directory', Path(main_file).parent.absolute(),
+            PDFLATEX + ['-output-directory', builddir,
                         config.tools_root / 'latex' / main_file],
             0,
             False,
@@ -267,8 +266,9 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
             print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
             return False
 
-    # show output filename
+    # link the output pdf
     output_pdf = Path(main_file).with_suffix('.pdf')
+    ensure_symlink(output_pdf, builddir / output_pdf, True)
 
     print(f'{cc.green}Pdf written to {output_pdf}{cc.reset}')
     return True

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -158,8 +158,9 @@ def build_problem_pdf(problem):
 
     for i in range(3):
         ret = util.exec_command(
-            PDFLATEX + ['-output-directory', builddir,
+            PDFLATEX + ['-aux-directory', builddir,
                         '-include-directory', config.tools_root / 'latex',
+                        '-output-directory', problem.path.absolute(),
                         builddir / 'problem.tex'],
             0,
             False,
@@ -169,9 +170,8 @@ def build_problem_pdf(problem):
             print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
             return False
 
-    # link the output pdf
+    # show output filename
     output_pdf = problem.path / 'problem.pdf'
-    ensure_symlink(output_pdf, builddir / 'problem.pdf', True)
 
     print(f'{cc.green}Pdf written to {output_pdf}{cc.reset}')
     return True
@@ -249,8 +249,9 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
 
     for i in range(3):
         ret = util.exec_command(
-            PDFLATEX + ['-output-directory', builddir,
+            PDFLATEX + ['-aux-directory', builddir,
                         '-include-directory', config.tools_root / 'latex',
+                        '-output-directory', Path(main_file).parent.absolute(),
                         config.tools_root / 'latex' / main_file],
             0,
             False,
@@ -260,9 +261,8 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
             print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
             return False
 
-    # link the output pdf
+    # show output filename
     output_pdf = Path(main_file).with_suffix('.pdf')
-    ensure_symlink(output_pdf, builddir / output_pdf, True)
 
     print(f'{cc.green}Pdf written to {output_pdf}{cc.reset}')
     return True

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -157,15 +157,18 @@ def build_problem_pdf(problem):
         })
 
     for i in range(3):
+        env = os.environ.copy()
+        env["TEXINPUTS"] = str(config.tools_root / 'latex') + ';';
         ret = util.exec_command(
             PDFLATEX + ['-aux-directory', builddir,
-                        '-include-directory', config.tools_root / 'latex',
                         '-output-directory', problem.path.absolute(),
                         builddir / 'problem.tex'],
             0,
             False,
             cwd=builddir,
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE,
+            env=env,
+            )
         if ret.ok is not True:
             print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
             return False
@@ -248,15 +251,18 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
     (builddir / f'contest-{build_type}s.tex').write_text(problems_data)
 
     for i in range(3):
+        env = os.environ.copy()
+        env["TEXINPUTS"] = str(config.tools_root / 'latex') + ';';
         ret = util.exec_command(
             PDFLATEX + ['-aux-directory', builddir,
-                        '-include-directory', config.tools_root / 'latex',
                         '-output-directory', Path(main_file).parent.absolute(),
                         config.tools_root / 'latex' / main_file],
             0,
             False,
             cwd=builddir,
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE,
+            env=env,
+            )
         if ret.ok is not True:
             print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
             return False

--- a/bin/util.py
+++ b/bin/util.py
@@ -413,7 +413,7 @@ def strip_newline(s):
 
 # When output is True, copy the file when args.cp is true.
 def ensure_symlink(link, target, output=False, relative=False):
-    # For output files: copy then on Windows, or when --cp is passed.
+    # For output files: copy them on Windows, or when --cp is passed.
     if output and (is_windows() or getattr(config.args, 'cp', False)):
         if link.exists() or link.is_symlink(): link.unlink()
         shutil.copyfile(target, link)

--- a/bin/util.py
+++ b/bin/util.py
@@ -413,7 +413,8 @@ def strip_newline(s):
 
 # When output is True, copy the file when args.cp is true.
 def ensure_symlink(link, target, output=False, relative=False):
-    if output and hasattr(config.args, 'cp') and config.args.cp == True:
+    # For output files: copy then on Windows, or when --cp is passed.
+    if output and (is_windows() or getattr(config.args, 'cp', False)):
         if link.exists() or link.is_symlink(): link.unlink()
         shutil.copyfile(target, link)
         return

--- a/bin/util.py
+++ b/bin/util.py
@@ -694,7 +694,7 @@ def exec_command(command, expect=0, crop=True, **kwargs):
     err = maybe_crop(stderr.decode('utf-8')) if stderr is not None else None
     out = maybe_crop(stdout.decode('utf-8')) if stdout is not None else None
 
-    if process.rusage:
+    if hasattr(process, 'rusage'):
         duration = process.rusage.ru_utime + process.rusage.ru_stime
         # It may happen that the Rusage is low, even though a timeout was raised, i.e. when calling sleep().
         # To prevent under-reporting the duration, we take the max with wall time in this case.

--- a/latex/contest-data.tex
+++ b/latex/contest-data.tex
@@ -2,4 +2,5 @@
 \subtitle{{%subtitle%}}
 \year{{%year%}}
 \author{{%author%}}
+\newcommand{\logofile}{{%logofile%}}
 {%testsession%}

--- a/latex/contest-problem.tex
+++ b/latex/contest-problem.tex
@@ -4,7 +4,7 @@
 	\renewcommand{\problemauthor}{{%problemauthor%}}
 	\renewcommand{\timelimit}{{%timelimit%}}
 	\input{{%problemdir%}/problem_statement/problem.en.tex}
-	\input{{%problemdir%}/samples.tex}
+	\input{{%builddir%}/samples.tex}
 	\renewcommand{\problemlabel}{}
 	\renewcommand{\problemyamlname}{}
 	\renewcommand{\problemauthor}{}

--- a/latex/contest.tex
+++ b/latex/contest.tex
@@ -33,7 +33,7 @@
 	
 	\vfill
 	\vfill
-	\includegraphics[height=5cm]{logo}
+	\includegraphics[height=5cm]{\logofile}
 	\vfill
 	
 	\listofproblems

--- a/latex/problem.tex
+++ b/latex/problem.tex
@@ -6,6 +6,6 @@
 	\renewcommand{\problemauthor}{{%problemauthor%}}
 	\renewcommand{\timelimit}{{%timelimit%}}
 	\input{{%problemdir%}/problem_statement/problem.en.tex}
-	\input{{%problemdir%}/samples.tex}
+	\input{{%builddir%}/samples.tex}
 \endgroup
 \end{document}


### PR DESCRIPTION
Instead of symlinking files, this MR passes the original locations of the files to `pdflatex`, removing the need for symlinks. I've not updated the code for the solution slides yet, but there we could do the same.

This also adds a little bit of Windows compatibility by adding `.as_posix()` to the paths we pass to LaTeX.