### PR TITLE
Use colorama for colored output

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -8,7 +8,7 @@ import re
 import zipfile
 import config
 import util
-from util import cc
+from colorama import Fore, Style
 from pathlib import Path
 
 
@@ -67,7 +67,7 @@ def build_problem_zip(problem, output, settings):
     for pattern, required in files:
         paths = list(util.glob(Path(problem), pattern))
         if required and len(paths) == 0:
-            print(f'{cc.red}No matches for required path {pattern}{cc.reset}.')
+            print(f'{Fore.RED}No matches for required path {pattern}{Style.RESET_ALL}.')
         for f in paths:
             # TODO: Fix this hack. Maybe just rename input_validators ->
             # input_format_validators everywhere?

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -562,7 +562,7 @@ class TestcaseRule(Rule):
                     else:
                         # different -> overwrite
                         if not forced:
-                            bar.warn(f'SKIPPED: {target.name}{cc.reset}' + msg)
+                            bar.warn(f'SKIPPED: {target.name}{Style.RESET_ALL}' + msg)
                             skipped = True
                             if ext == '.in':
                                 skipped_in = True
@@ -592,7 +592,7 @@ class TestcaseRule(Rule):
 
                     # remove old target
                     if not forced:
-                        bar.warn(f'SKIPPED: {target.name}{cc.reset}' + msg)
+                        bar.warn(f'SKIPPED: {target.name}{Style.RESET_ALL}' + msg)
                         skipped = True
                         continue
                     else:

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import config
 import util
 from util import *
+from colorama import Fore, Style
 
 PDFLATEX = ['pdflatex', '-interaction=nonstopmode', '-halt-on-error']
 
@@ -165,14 +166,14 @@ def build_problem_pdf(problem):
             env=env,
             )
         if ret.ok is not True:
-            print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
+            print(f'{Fore.RED}Failure compiling pdf:{Style.RESET_ALL}\n{ret.out}')
             return False
 
     # link the output pdf
     output_pdf = problem.path / 'problem.pdf'
     ensure_symlink(output_pdf, builddir / 'problem.pdf', True)
 
-    print(f'{cc.green}Pdf written to {output_pdf}{cc.reset}')
+    print(f'{Fore.GREEN}Pdf written to {output_pdf}{Style.RESET_ALL}')
     return True
 
 
@@ -250,12 +251,12 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
             env=env,
             )
         if ret.ok is not True:
-            print(f'{cc.red}Failure compiling pdf:{cc.reset}\n{ret.out}')
+            print(f'{Fore.RED}Failure compiling pdf:{Style.RESET_ALL}\n{ret.out}')
             return False
 
     # link the output pdf
     output_pdf = Path(main_file).with_suffix('.pdf')
     ensure_symlink(output_pdf, builddir / output_pdf, True)
 
-    print(f'{cc.green}Pdf written to {output_pdf}{cc.reset}')
+    print(f'{Fore.GREEN}Pdf written to {output_pdf}{Style.RESET_ALL}')
     return True

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -11,6 +11,7 @@ import run
 import validate
 import shlex
 from util import *
+from colorama import Fore, Style
 
 
 # A problem.
@@ -383,9 +384,9 @@ class Problem:
         def single_verdict(row, testcase):
             if testcase.name in row:
                 if row[testcase.name]:
-                    return cc.green + '1' + cc.reset
+                    return Fore.GREEN + '1' + Style.RESET_ALL
                 else:
-                    return cc.red + '0' + cc.reset
+                    return Fore.RED + '0' + Style.RESET_ALL
             else:
                 return '-'
 
@@ -418,23 +419,23 @@ class Problem:
             '\nVerdict analysis table. Submissions are ordered per column as above. Higher '
             'scores indicate they are critical to break some submissions. Only cases breaking at least one submission are listed.'
         )
-        print(f'{cc.red}0{cc.reset}: submission fails testcase')
-        print(f'{cc.green}1{cc.reset}: submission passes testcase\n')
+        print(f'{Fore.RED}0{Style.RESET_ALL}: submission fails testcase')
+        print(f'{Fore.GREEN}1{Style.RESET_ALL}: submission passes testcase\n')
 
         for testcase in testcases:
             # Skip all AC testcases
             if all(map(lambda row: testcase.name in row and row[testcase.name], verdict_table)):
                 continue
 
-            color = cc.reset
+            color = Style.RESET_ALL
             if len(scores_list) > 6 and scores[testcase.name] >= scores_list[-6]:
-                color = cc.orange
+                color = Fore.YELLOW
             if len(scores_list) > 3 and scores[testcase.name] >= scores_list[-3]:
-                color = cc.red
+                color = Fore.RED
             print(f'{str(testcase.name):<60}', end=' ')
             resultant = make_verdict(testcase)
             print(resultant, end='  ')
-            print(f'{color}{scores[testcase.name]:0.3f}{cc.reset}  ', end='')
+            print(f'{color}{scores[testcase.name]:0.3f}{Style.RESET_ALL}  ', end='')
             if resultant in resultant_id:
                 print(str.format('(Type {})', resultant_id[resultant]), end='')
             print(end='\n')

--- a/bin/run.py
+++ b/bin/run.py
@@ -5,6 +5,7 @@ import interactive
 import os
 
 from util import *
+from colorama import Fore, Style
 
 
 class Testcase:
@@ -75,7 +76,7 @@ class Testcase:
             data = ''
             if ret.ok is not True or config.args.error:
                 if ret.err and ret.out:
-                    ret.out = ret.err + f'\n{cc.red}VALIDATOR STDOUT{cc.reset}\n' + cc.orange + ret.out
+                    ret.out = ret.err + f'\n{Fore.RED}VALIDATOR STDOUT{Style.RESET_ALL}\n' + Fore.YELLOW + ret.out
                 elif ret.err:
                     data = ret.err
                 elif ret.out:
@@ -108,7 +109,7 @@ class Testcase:
             # Remove testcase if specified.
             elif validator_type == 'input' and hasattr(config.args,
                                                        'remove') and config.args.remove:
-                bar.log(cc.red + 'REMOVING TESTCASE!' + cc.reset)
+                bar.log(Fore.RED + 'REMOVING TESTCASE!' + Style.RESET_ALL)
                 if testcase.in_path.exists():
                     testcase.in_path.unlink()
                 if testcase.ans_path.exists():
@@ -366,15 +367,15 @@ class Submission(program.Program):
 
         # Use a bold summary line if things were printed before.
         if bar.logged:
-            color = cc.boldgreen if self.verdict in self.expected_verdicts else cc.boldred
-            boldcolor = cc.bold
+            color = Style.BRIGHT + Fore.GREEN if self.verdict in self.expected_verdicts else Style.BRIGHT + Fore.RED
+            boldcolor = Style.BRIGHT
         else:
-            color = cc.green if self.verdict in self.expected_verdicts else cc.red
+            color = Fore.GREEN if self.verdict in self.expected_verdicts else Fore.RED
             boldcolor = ''
 
         printed_newline = bar.finalize(
             message=
-            f'{max_duration:6.3f}s {color}{self.print_verdict:<20}{cc.reset} @ {verdict_run.testcase.name}'
+            f'{max_duration:6.3f}s {color}{self.print_verdict:<20}{Style.RESET_ALL} @ {verdict_run.testcase.name}'
         )
 
         return (self.verdict in self.expected_verdicts, printed_newline)
@@ -405,22 +406,22 @@ class Submission(program.Program):
 
                 assert result.err is None and result.out is None
                 if result.duration > self.problem.settings.timeout:
-                    status = f'{cc.red}Aborted!'
+                    status = f'{Fore.RED}Aborted!'
                     config.n_error += 1
                 elif result.ok is not True and result.ok != -9:
                     config.n_error += 1
                     status = None
                     print(
-                        f'{cc.red}Run time error!{cc.reset} exit code {result.ok} {cc.bold}{result.duration:6.3f}s{cc.reset}'
+                        f'{Fore.RED}Run time error!{Style.RESET_ALL} exit code {result.ok} {Style.BRIGHT}{result.duration:6.3f}s{Style.RESET_ALL}'
                     )
                 elif result.duration > self.problem.settings.timelimit:
-                    status = f'{cc.orange}Done (TLE):'
+                    status = f'{Fore.YELLOW}Done (TLE):'
                     config.n_warn += 1
                 else:
-                    status = f'{cc.green}Done:'
+                    status = f'{Fore.GREEN}Done:'
 
                 if status:
-                    print(f'{status}{cc.reset} {cc.bold}{result.duration:6.3f}s{cc.reset}')
+                    print(f'{status}{Style.RESET_ALL} {Style.BRIGHT}{result.duration:6.3f}s{Style.RESET_ALL}')
                 print()
 
             else:
@@ -433,11 +434,11 @@ class Submission(program.Program):
                 if result.verdict != 'ACCEPTED':
                     config.n_error += 1
                     print(
-                        f'{cc.red}{result.verdict}{cc.reset} {cc.bold}{result.duration:6.3f}s{cc.reset}'
+                        f'{Fore.RED}{result.verdict}{Style.RESET_ALL} {Style.BRIGHT}{result.duration:6.3f}s{Style.RESET_ALL}'
                     )
                 else:
                     print(
-                        f'{cc.green}{result.verdict}{cc.reset} {cc.bold}{result.duration:6.3f}s{cc.reset}'
+                        f'{Fore.GREEN}{result.verdict}{Style.RESET_ALL} {Style.BRIGHT}{result.duration:6.3f}s{Style.RESET_ALL}'
                     )
 
     # Run the submission using stdin as input.
@@ -504,13 +505,13 @@ while True:
                     config.n_error += 1
                     status = None
                     print(
-                        f'{cc.red}Run time error!{cc.reset} exit code {result.ok} {cc.bold}{result.duration:6.3f}s{cc.reset}'
+                        f'{Fore.RED}Run time error!{Style.RESET_ALL} exit code {result.ok} {Style.BRIGHT}{result.duration:6.3f}s{Style.RESET_ALL}'
                     )
                 else:
-                    status = f'{cc.green}Done:'
+                    status = f'{Fore.GREEN}Done:'
 
                 if status:
-                    print(f'{status}{cc.reset} {cc.bold}{result.duration:6.3f}s{cc.reset}')
+                    print(f'{status}{Style.RESET_ALL} {Style.BRIGHT}{result.duration:6.3f}s{Style.RESET_ALL}')
                 print()
             finally:
                 os.close(r)

--- a/bin/stats.py
+++ b/bin/stats.py
@@ -1,4 +1,5 @@
 from util import *
+from colorama import Fore, Style
 import generate
 
 
@@ -7,15 +8,15 @@ import generate
 def _get_stat(count, threshold=True, upper_bound=None):
     if threshold is True:
         if count >= 1:
-            return cc.white + 'Y' + cc.reset
+            return Fore.WHITE + 'Y' + Style.RESET_ALL
         else:
-            return cc.red + 'N' + cc.reset
-    color = cc.white
+            return Fore.RED + 'N' + Style.RESET_ALL
+    color = Fore.WHITE
     if upper_bound != None and count > upper_bound:
-        color = cc.orange
+        color = Fore.YELLOW
     if count < threshold:
-        color = cc.red
-    return color + str(count) + cc.reset
+        color = Fore.RED
+    return color + str(count) + Style.RESET_ALL
 
 
 def stats(problems):
@@ -59,10 +60,10 @@ def stats(problems):
         else:
             width = len(header)
             header_string += ' {:>' + str(width) + '}'
-            format_string += ' {:>' + str(width + len(cc.white) + len(cc.reset)) + '}'
+            format_string += ' {:>' + str(width + len(Fore.WHITE) + len(Style.RESET_ALL)) + '}'
 
     header = header_string.format(*headers)
-    print(cc.bold + header + cc.reset)
+    print(Style.BRIGHT + header + Style.RESET_ALL)
 
     for problem in problems:
         generated_testcases = {
@@ -113,9 +114,9 @@ def stats(problems):
         if verified:
             if not comment:
                 comment = 'DONE'
-            comment = cc.green + comment + cc.reset
+            comment = Fore.GREEN + comment + Style.RESET_ALL
         else:
-            comment = cc.orange + comment + cc.reset
+            comment = Fore.YELLOW + comment + Style.RESET_ALL
 
         print(
             format_string.format(

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -43,6 +43,8 @@ from util import *
 if not is_windows():
     import argcomplete  # For automatic shell completions
 
+# Initialize colorama for printing coloured output. On Windows, this captures
+# stdout and replaces ANSI colour codes by calls to change the terminal colour.
 colorama.init()
 
 # List of high level todos:

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -20,6 +20,7 @@ import os
 import sys
 import tempfile
 import shutil
+import colorama
 
 from pathlib import Path
 
@@ -41,6 +42,8 @@ from util import *
 
 if not is_windows():
     import argcomplete  # For automatic shell completions
+
+colorama.init()
 
 # List of high level todos:
 # TODO: Do more things in parallel (running testcases, building submissions)
@@ -560,7 +563,7 @@ def run_parsed_arguments(args):
         if level == 'problemset' and action == 'pdf' and not (hasattr(config.args, 'all')
                                                               and config.args.all):
             continue
-        print(cc.bold, 'PROBLEM ', problem.name, cc.reset, sep='')
+        print(Style.BRIGHT, 'PROBLEM ', problem.name, Style.RESET_ALL, sep='')
 
         # TODO: Remove usages of settings.
         settings = problem.settings
@@ -626,7 +629,7 @@ def run_parsed_arguments(args):
             print()
 
     if level == 'problemset':
-        print(f'{cc.bold}CONTEST {contest}{cc.reset}')
+        print(f'{Style.BRIGHT}CONTEST {contest}{Style.RESET_ALL}')
 
         # build pdf for the entire contest
         if action in ['pdf']:

--- a/bin/util.py
+++ b/bin/util.py
@@ -14,6 +14,7 @@ import threading
 import signal
 
 from pathlib import Path
+from colorama import Fore, Style
 
 
 def is_windows():
@@ -28,62 +29,28 @@ if not is_windows():
     import resource
 
 
-# color printing
-class Colorcodes(object):
-    def __init__(self):
-        if not is_windows():
-            self.bold = '\033[;1m'
-            self.reset = '\033[0;0m'
-            self.blue = '\033[;96m'
-            self.green = '\033[;32m'
-            self.orange = '\033[;33m'
-            self.red = '\033[;31m'
-            self.white = '\033[;39m'
-
-            self.boldblue = '\033[1;34m'
-            self.boldgreen = '\033[1;32m'
-            self.boldorange = '\033[1;33m'
-            self.boldred = '\033[1;31m'
-        else:
-            self.bold = ''
-            self.reset = ''
-            self.blue = ''
-            self.green = ''
-            self.orange = ''
-            self.red = ''
-            self.white = ''
-
-            self.boldblue = ''
-            self.boldgreen = ''
-            self.boldorange = ''
-            self.boldred = ''
-
-
-cc = Colorcodes()
-
-
 def debug(*msg):
-    print(cc.blue, end='')
+    print(Fore.CYAN, end='')
     print('DEBUG:', *msg, end='')
-    print(cc.reset)
+    print(Style.RESET_ALL)
 
 
 def log(msg):
-    print(cc.green + 'LOG: ' + msg + cc.reset)
+    print(Fore.GREEN + 'LOG: ' + msg + Style.RESET_ALL)
 
 
 def warn(msg):
-    print(cc.orange + 'WARNING: ' + msg + cc.reset)
+    print(Fore.YELLOW + 'WARNING: ' + msg + Style.RESET_ALL)
     config.n_warn += 1
 
 
 def error(msg):
-    print(cc.red + 'ERROR: ' + msg + cc.reset)
+    print(Fore.RED + 'ERROR: ' + msg + Style.RESET_ALL)
     config.n_error += 1
 
 
 def fatal(msg):
-    print(cc.red + 'FATAL ERROR: ' + msg + cc.reset)
+    print(Fore.RED + 'FATAL ERROR: ' + msg + Style.RESET_ALL)
     exit(1)
 
 
@@ -171,7 +138,7 @@ class ProgressBar:
         item = '' if item is None else (item if isinstance(item, str) else item.name)
         if width is not None and len(item) > width: item = item[:width]
         if width is None: width = 0
-        return f'{cc.blue}{prefix}{cc.reset}: {item:<{width}}'
+        return f'{Fore.CYAN}{prefix}{Style.RESET_ALL}: {item:<{width}}'
 
     def get_prefix(self):
         return ProgressBar.action(self.prefix, self.item, self.item_width, self.total_width())
@@ -243,11 +210,11 @@ class ProgressBar:
     def _format_data(data):
         if not data: return ''
         prefix = '  ' if data.count('\n') <= 1 else '\n'
-        return prefix + cc.orange + strip_newline(crop_output(data)) + cc.reset
+        return prefix + Fore.YELLOW + strip_newline(crop_output(data)) + Style.RESET_ALL
 
     # Log can be called multiple times to make multiple persistent lines.
     # Make sure that the message does not end in a newline.
-    def log(self, message='', data='', color=cc.green, *, needs_lock=True, resume=True):
+    def log(self, message='', data='', color=Fore.GREEN, *, needs_lock=True, resume=True):
         if needs_lock: self.lock.acquire()
 
         if message is None: message = ''
@@ -264,7 +231,7 @@ class ProgressBar:
               color,
               message,
               ProgressBar._format_data(data),
-              cc.reset,
+              Style.RESET_ALL,
               sep='',
               flush=True)
 
@@ -283,13 +250,13 @@ class ProgressBar:
 
     def warn(self, message='', data=''):
         config.n_warn += 1
-        self.log(message, data, cc.orange)
+        self.log(message, data, Fore.YELLOW)
 
     # Error removes the current item from the in_progress set.
     def error(self, message='', data='', needs_lock=True):
         if needs_lock: self.lock.acquire()
         config.n_error += 1
-        self.log(message, data, cc.red, needs_lock=False, resume=False)
+        self.log(message, data, Fore.RED, needs_lock=False, resume=False)
         self._release_item()
         if needs_lock: self.lock.release()
 
@@ -305,7 +272,7 @@ class ProgressBar:
         if not self.logged:
             if not success: config.n_error += 1
             if config.args.verbose or not success:
-                self.log(message, data, needs_lock=False, color=cc.green if success else cc.red)
+                self.log(message, data, needs_lock=False, color=Fore.GREEN if success else Fore.RED)
 
         self._release_item()
         if self.parent:
@@ -347,7 +314,7 @@ class ProgressBar:
 
         # Print 'DONE' when nothing was printed yet but a summary was requested.
         if print_done and not self.global_logged and not message:
-            message = f'{cc.green}Done{cc.reset}'
+            message = f'{Fore.GREEN}Done{Style.RESET_ALL}'
 
         if message:
             print(self.get_prefix(), message, sep='')
@@ -529,7 +496,7 @@ def crop_output(output):
         cropped = True
 
     if cropped:
-        output += cc.orange + 'Use -e to show more.' + cc.reset
+        output += Fore.YELLOW + 'Use -e to show more.' + Style.RESET_ALL
     return output
 
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ required dependencies manually.
 
 -   Python 3 (>= 3.6).
 -   The [yaml library](https://pyyaml.org/wiki/PyYAMLDocumentation) via `pip install pyyaml` or the `python[3]-yaml` Arch Linux package.
+-   The [colorama library](https://pypi.org/project/colorama/) via `pip install colorama` or the `python[3]-colorama` Arch Linux package.
 -   The `argcomplete` library for command line argument completion. Install via
     `python[3]-argcomplete`.
 	- Note that actually using `argcomplete` is optional, but recommended.


### PR DESCRIPTION
Instead of implementing terminal colors in a custom way, this uses the [colorama](https://pypi.org/project/colorama/) library, which makes the code a bit cleaner and (most importantly) works on all platforms, specifically supporting Windows too.

As a small change the orange text now changed to yellow because orange is not available, but IMO it looks fine.