### PR TITLE
Use st_mtime to detect last modification

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -449,7 +449,7 @@ class TestcaseRule(Rule):
             last_change = 0
             t.cache_data = {}
             if t.manual:
-                last_change = max(last_change, (problem.path / t.source).stat().st_ctime)
+                last_change = max(last_change, (problem.path / t.source).stat().st_mtime)
                 t.cache_data['source'] = str(t.source)
             else:
                 last_change = max(last_change, t.generator.program.timestamp)
@@ -467,13 +467,13 @@ class TestcaseRule(Rule):
             if not target_infile.is_file(): return False
             if not target_ansfile.is_file(): return False
 
-            last_change = max(last_change, target_infile.stat().st_ctime)
-            last_change = max(last_change, target_ansfile.stat().st_ctime)
+            last_change = max(last_change, target_infile.stat().st_mtime)
+            last_change = max(last_change, target_ansfile.stat().st_mtime)
 
             if not meta_path.is_file(): return False
 
             meta_yaml = yaml.safe_load(meta_path.open())
-            return meta_path.stat().st_ctime >= last_change and meta_yaml == t.cache_data
+            return meta_path.stat().st_mtime >= last_change and meta_yaml == t.cache_data
 
         if up_to_date():
             check_deterministic()

--- a/bin/program.py
+++ b/bin/program.py
@@ -322,7 +322,7 @@ class Program:
         for f in self.source_files:
             ensure_symlink(self.tmpdir / f.name, f)
             self.input_files.append(self.tmpdir / f.name)
-            self.timestamp = max(self.timestamp, f.stat().st_ctime)
+            self.timestamp = max(self.timestamp, f.stat().st_mtime)
 
         if not self._get_language(self.source_files): return False
 
@@ -340,7 +340,7 @@ class Program:
 
         # Compare the latest source timestamp (self.timestamp) to the last build.
         up_to_date = meta_path.is_file(
-        ) and meta_path.stat().st_ctime >= self.timestamp and meta_path.read_text() == ' '.join(
+        ) and meta_path.stat().st_mtime >= self.timestamp and meta_path.read_text() == ' '.join(
             self.compile_command)
 
         if not up_to_date or config.args.force_build:


### PR DESCRIPTION
According to [the docs](https://docs.python.org/3/library/stat.html):
> stat.ST_CTIME
> The “ctime” as reported by the operating system. On some systems (like Unix) is the time of the last metadata change, and, on others (like Windows), is the creation time (see platform documentation for details).

This resulted in programs not recompiling on Windows. I've changed this to `st_mtime`, which is the modified time on all platforms, which I believe should be the right time here.