### PR TITLE
Allow having no output format validators when validation=default

### DIFF
--- a/bin/problem.py
+++ b/bin/problem.py
@@ -259,10 +259,13 @@ class Problem:
         paths = (glob(problem.path / (validator_dir + '_validators'), '*') +
                  glob(problem.path / (validator_dir + '_format_validators'), '*'))
 
-        if len(paths) == 0 and validator_type != 'output_format':
-            error(f'No {validator_type} validators found.')
-            problem._validators[key] = False
-            return False
+        if len(paths) == 0:
+            if validator_type == 'output_format':
+                log(f'No {validator_type} validators found (not required).')
+            else:
+                error(f'No {validator_type} validators found, at least one is required.')
+                problem._validators[key] = False
+                return False
         if validator_type == 'output' and problem.interactive and len(paths) > 1:
             error(
                 f'Found more than one output validator, but validation type {problem.settings.validation} needs exactly one.'

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -261,7 +261,7 @@ class Problem:
 
         if len(paths) == 0:
             if validator_type == 'output_format':
-                log(f'No {validator_type} validators found (not required).')
+                log(f'No {validator_type} validators found.')
             else:
                 error(f'No {validator_type} validators found, at least one is required.')
                 problem._validators[key] = False

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -230,8 +230,8 @@ class Problem:
         assert validator_type in ['input_format', 'output_format', 'output']
 
         # For custom validation, treat 'output' and 'output_format' validators the same.
-        if problem.settings.validation != 'default' and validator_type == 'output':
-            validator_type = 'output_format'
+        if problem.settings.validation != 'default' and validator_type == 'output_format':
+            validator_type = 'output'
 
         key = (validator_type, check_constraints)
         if key in problem._validators:
@@ -259,12 +259,11 @@ class Problem:
         paths = (glob(problem.path / (validator_dir + '_validators'), '*') +
                  glob(problem.path / (validator_dir + '_format_validators'), '*'))
 
-        if len(paths) == 0:
-            if validator_type != 'output_format':
-                warn(f'No {validator_type} validators found.')
+        if len(paths) == 0 and validator_type != 'output_format':
+            error(f'No {validator_type} validators found.')
             problem._validators[key] = False
             return False
-        if validator_type == 'output_format' and problem.interactive and len(paths) > 1:
+        if validator_type == 'output' and problem.interactive and len(paths) > 1:
             error(
                 f'Found more than one output validator, but validation type {problem.settings.validation} needs exactly one.'
             )
@@ -471,7 +470,7 @@ class Problem:
             log('Not validating .ans for interactive problem.')
             return True
 
-        if not validators:
+        if validators is False:
             return False
 
         testcases = problem.testcases(needans=validator_type == 'output_format', include_bad=True)


### PR DESCRIPTION
- Note about lines 233-234: treating `output` and `output_format` the same is now done by setting `valitator_type = output` instead of the other way around, because then the condition on line 262 actually makes sense.
  - This change also has effect on line 269.
- Because the returned `validators` list is now allowed to be empty, I had to change the condition on line 476 from `not validators` to `validators not is False`, because the empty list is a false-y value in Python.

This works on some FPC problems that have `validation=default` (some of them having output format validators), and I ran `bapctools validate` on the two BAPC contests as well, seems to work on my machine :tm: :stuck_out_tongue: 