### PR TITLE
Fix comment about 'interactive' validation

### DIFF
--- a/skel/problem/problem.yaml
+++ b/skel/problem/problem.yaml
@@ -6,7 +6,7 @@ source: {%source%}
 source_url: {%source_url%}
 license: {%license%}
 rights_owner: {%rights_owner%}
-# 'default', 'custom', or 'interactive'
+# 'default', 'custom', or 'custom interactive'
 validation: {%validation%}
 
 # One or more of:


### PR DESCRIPTION
The comment incorrectly advertised `'interactive'` as one of the validation options, but that should be `'custom interactive'`.