### PR TITLE
Consistent indents in skel/problem/solution.tex

### DIFF
--- a/skel/problem/problem_statement/solution.tex
+++ b/skel/problem/problem_statement/solution.tex
@@ -1,7 +1,7 @@
 % TODO: Remove this comment when you write actual solutions.
 \begin{frame}
 	\frametitle{\problemtitle}
-    \begin{itemize}
+	\begin{itemize}
 		\item Print $4\sqrt n$ with sufficiently many digits.
-    \end{itemize}
+	\end{itemize}
 \end{frame}


### PR DESCRIPTION
I noticed that the indentation in `solution.tex` in the problem skeleton had mixed tabs/spaces as indentation, so I changed it to use tabs only, to make it consistent with the rest of the problem skeleton.

I'd rather see spaces instead of tabs as indentation, but then that would have to change in many more places. For now, I'm just making it consistent :slightly_smiling_face: 