### PR TITLE
[latex] Switch to `latexmk` and add `--watch` argument

### DIFF
--- a/bin/tools.py
+++ b/bin/tools.py
@@ -343,12 +343,16 @@ Run this from one of:
                            '-a',
                            action='store_true',
                            help='Create problem statements for individual problems as well.')
-    pdfparser.add_argument('--web', action='store_true', help='Create a web version of the pdf.')
     pdfparser.add_argument('--cp',
                            action='store_true',
                            help='Copy the output pdf instead of symlinking it.')
     pdfparser.add_argument('--no-timelimit', action='store_true', help='Do not print timelimits.')
-    pdfparser.add_argument('-1', action='store_true', help='Only run pdflatex once')
+    pdfparser.add_argument('--watch',
+                           '-w',
+                           action='store_true',
+                           help='Continuously compile the pdf whenever a `problem_statement.tex` changes. Note that this does not pick up changes to `*.yaml` configuration files.')
+    pdfparser.add_argument('--web', action='store_true', help='Create a web version of the pdf.')
+    pdfparser.add_argument('-1', action='store_true', help='Only run the LaTeX compiler once.')
 
     # Solution slides
     solparser = subparsers.add_parser('solutions',
@@ -370,8 +374,12 @@ Run this from one of:
     solparser.add_argument('--contest-id',
                            action='store',
                            help='Contest ID to use when reading from the API. Only useful with --order-from-ccs. Defaults to value of contest_id in contest.yaml.')
+    solparser.add_argument('--watch',
+                           '-w',
+                           action='store_true',
+                           help='Continuously compile the pdf whenever a `solution.tex` changes. Note that this does not pick up changes to `*.yaml` configuration files.')
     solparser.add_argument('--web', action='store_true', help='Create a web version of the pdf.')
-    solparser.add_argument('-1', action='store_true', help='Only run pdflatex once')
+    solparser.add_argument('-1', action='store_true', help='Only run the LaTeX compiler once.')
 
     # Validation
     validate_parser = subparsers.add_parser('validate',

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -174,16 +174,17 @@ Furthermore, it removes generated `testdata.yaml`.
 
 Renders a pdf for the current problem or contest. The pdf is written to `problem.pdf` or `contest.pdf` respectively.
 
-- Note 1: `pdflatex` is called exactly once usually. You may need to call it multiple times after big changes to the problem/contest. `bt zip` *does* run `pdflatex` multiple times.
-- Note 2: All LaTeX compilation is done in tmpfs (`/tmp/` on linux). The resulting pdfs will be symlinks into the temporary directory. See the [Implementation notes](implementation_notes.md#building-latex-files) for more.
+**Note:** All LaTeX compilation is done in tmpfs (`/tmp/` on linux). The resulting pdfs will be symlinks into the temporary directory. See the [Implementation notes](implementation_notes.md#building-latex-files) for more.
 
 
 **Flags**
 
-- `--no-timelimit`: When passed, time limits will not be shown in the problem/contest pdfs.
 - `--all`/`-a`: When run from the contest level, this enables building pdfs for all problems in the contest as well.
 - `--cp`: Instead of symlinking the final pdf, copy it into the problem/contest directory.
+- `--no-timelimit`: When passed, time limits will not be shown in the problem/contest pdfs.
+- `--watch`/`-w`: Continuously compile the pdf whenever a `problem_statement.tex` changes. Note that this does not pick up changes to `*.yaml` configuration files.
 - `--web`: Build a web version of the pdf. This uses [contest-web.tex](../latex/contest-web.tex) instead of [contest.tex](../latex/contest.text) and [solutions-web.tex](../latex/solutions-web.tex) instead of [solutions.tex](../latex/solutions.tex). In practice, the only thing this does is to remove empty _this is not a blank page_ pages and make the pdf single sides.
+- `-1`: Run the LaTeX compiler only once.
 
 
 ## `solutions`
@@ -193,9 +194,13 @@ See the [Implementation notes](implementation_notes.md#building-latex-files) for
 
 **Flags**
 
-- `--order`: The order of the problems, e.g. `BDCA`. Can be used to order problems from easy to difficult. When labels have multiple letters, `B1,A1,A2,B2` is also allowed.
 - `--cp`: Instead of symlinking the final pdf, copy it into the contest directory.
+- `--order`: The order of the problems, e.g. `BDCA`. Can be used to order problems from easy to difficult. When labels have multiple letters, `B1,A1,A2,B2` is also allowed.
+- `--order-from-ccs`: Order the problems by increasing difficulty, extracted from the api, e.g.: https://www.domjudge.org/demoweb. Defaults to value of ccs_url in contest.yaml.
+- `--contest-id`: Contest ID to use when reading from the API. Only useful with `--order-from-ccs`. Defaults to value of `contest_id` in `contest.yaml`.
+- `--watch`/`-w`: Continuously compile the pdf whenever a `problem_statement.tex` changes. Note that this does not pick up changes to `*.yaml` configuration files.
 - `--web`: Build a web version of the pdf. This uses [contest-web.tex](../latex/contest-web.tex) instead of [contest.tex](../latex/contest.text) and [solutions-web.tex](../latex/solutions-web.tex) instead of [solutions.tex](../latex/solutions.tex). In practice, the only thing this does is to remove empty _this is not a blank page_ pages.
+- `-1`: Run the LaTeX compiler only once.
 
 ## `stats`
 

--- a/doc/implementation_notes.md
+++ b/doc/implementation_notes.md
@@ -96,8 +96,9 @@ Testcases are only re-generated when changes were made. This is done with the fo
 
 # Building LaTeX files
 
-## Problem/contest pdf
-**LaTeX setup**
+## Problem statement pdfs
+
+### Per-problem pdf
 
 The per-problem pdfs are created inside `<tmpdir>/<problemname>`:
 
@@ -108,8 +109,14 @@ The per-problem pdfs are created inside `<tmpdir>/<problemname>`:
 
 The statement is compiled using:
 ```
-pdflatex -interaction=nonstopmode -halt-on-error -output-directory ~tmpdir/<problemname> ~tmpdir/<problemname>/problem.tex
+latexmk -cd -g -pdf -pdflatex='pdflatex -interaction=nonstopmode -halt-on-error' [-pvc] [-e $max_repeat=1] -output-directory=~tmpdir/<problemname> ~tmpdir/<problemname>/problem.tex
 ```
+
+The `-pvc` option is only passed to `latexmk` when `--watch` is passed to BAPCtools.
+The `-e $max_repeat=1` option is only passed to `latexmk` when `-1` is passed to BAPCtools.
+
+### Full contest pdf
+
 After creating the `samples.tex` for each problem, the contest pdf is created in `~tmpdir/<contestname>` like this:
 
 * `~tmp/<contestname>/contest_data.tex`: a filled in copy of [contest_data.tex](../latex/contest-data.tex) containing the name, subtitle, year, and authors of the contest.
@@ -120,7 +127,9 @@ After creating the `samples.tex` for each problem, the contest pdf is created in
 
 The statement is compiled using:
 
-`pdflatex -interaction=nonstopmode -halt-on-error -output-directory ~tmpdir/<contestname> ~tmpdir/<contestname>/contest[-web].tex`.
+```
+latexmk -cd -g -pdf -pdflatex='pdflatex -interaction=nonstopmode -halt-on-error' [-pvc] [-e $max_repeat=1] -output-directory=~tmpdir/<contestname> ~tmpdir/<problemname>/contest[-web].tex
+```
 
 ## Solution slides
 

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ required dependencies manually.
 Optional dependencies, required for some subcommands:
 -   The [ruamel.yaml library](https://pypi.org/project/ruamel.yaml/) via `pip install ruamel.yaml` or the `python[3]-ruamel-yaml` Arch Linux package.
     - This is only needed for commands that update `generators.yaml`.
--   The `pdflatex` command, provided by `texlive-bin` on Arch Linux and
+-   The `latexmk` and `pdflatex` commands, provided by `texlive-bin` on Arch Linux and
     potentially some specific LaTeX packages (like tikz) provided by
 	`texlive-extra`.
 	These are only needed for building `pdf` files, not for `run` and `validate` and such.


### PR DESCRIPTION
Wanted my PDFs to autocompile on changes, so I added a `--watch` argument to `bt pdf` and `bt solutions` :smile:

To implement this, I switched to `latexmk`, which (according to its `man` page) "automates the process of compiling a LaTeX document", and should be included in recent `texlive` installations. It calls `pdflatex` as often as is required (instead of the fixed three times, as it was until now), and supports continuous previews, which saves the effort of having to implement file watching from Python. This has as downside that it only tracks changes in the TeX files and does not track changes in `*.yaml` config files, but I'm okay with that :slightly_smiling_face: 