### PR TITLE
Fix display of leading/multiple spaces in samples

### DIFF
--- a/bin/latex.py
+++ b/bin/latex.py
@@ -49,9 +49,10 @@ def tex_escape(text):
     if has_newline:
         text = text[:-1]
     text = regex.sub(lambda match: conv[match.group()], text)
+    # Escape multiple spaces separately
+    text = re.sub('  +', lambda m: '\\phantom{' + ('.' * len(m.group())) + '}', text)
     # Escape leading spaces separately
-    regex = re.compile('^ ')
-    text = regex.sub('\\\\phantom{.}', text)
+    text = re.compile('^ ', re.MULTILINE).sub('\\\\phantom{.}', text)
     if has_newline:
         text += '\n'
     return text


### PR DESCRIPTION
When creating the problem "Fraud Checking" for the Freshmen Programming Contest 2021 (archived at https://commissies.ch.tudelft.nl/chipcie/?page=archief), we noticed that leading/multiple spaces are not displayed correctly in the Sample Inputs/Outputs. This PR fixes this in two parts:

- Leading spaces were only displayed in samples when they were at the start of the first line. To also display them at the start of following lines, I've added the flag `re.MULTILINE` (line 55).
- Multiple spaces were globbed together by the TeX compiler, so I replaced `'  +'` with a `\phantom{...}` command, with as many `.`s as the number of spaces (line 53).

I decided to do the multiple-spaces-check _before_ the leading-spaces-check, so that a line with multiple leading spaces will only get one `\phantom` command at the start.