### PR TITLE
No longer rename input_validators to input_format_validators

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -120,9 +120,7 @@ def build_problem_zip(problem, output, settings):
         for f in paths:
             # NOTE: Directories are skipped because ZIP only supports files.
             if f.is_file():
-                # TODO: Fix this hack. Maybe just rename input_validators ->
-                # input_format_validators everywhere?
-                out = Path(str(f).replace('input_validators', 'input_format_validators'))
+                out = f
                 out = out.relative_to(problem.path)
                 # For Kattis, prepend the problem shortname to all files.
                 if config.args.kattis:

--- a/bin/export.py
+++ b/bin/export.py
@@ -120,8 +120,7 @@ def build_problem_zip(problem, output, settings):
         for f in paths:
             # NOTE: Directories are skipped because ZIP only supports files.
             if f.is_file():
-                out = f
-                out = out.relative_to(problem.path)
+                out = f.relative_to(problem.path)
                 # For Kattis, prepend the problem shortname to all files.
                 if config.args.kattis:
                     out = problem.name / out


### PR DESCRIPTION
Kattis' Problemtools now shows a deprecation warning when using `input_format_validators`, so I guess we no longer need the rename :smile:

Output from `verifyproblem`:
![image](https://user-images.githubusercontent.com/9739541/120066940-42400600-c079-11eb-8e1c-e4fcb1d61f3e.png)
