### PR TITLE
[contest] Fix missing API URL when not passed via command line

### DIFF
--- a/bin/contest.py
+++ b/bin/contest.py
@@ -56,7 +56,7 @@ def problemset_yaml():
 
 def get_api():
     api = None
-    if hasattr(config.args, 'api') and config.args.api is not None:
+    if getattr(config.args, 'api', None):
         api = config.args.api
     else:
         if contest_yaml() is None or 'api' not in contest_yaml():


### PR DESCRIPTION
Turns out that `hasattr(config.args, 'api')` always returned `True`, because it was set to the default value `None`. I've added an `is not None` check for this reason.

Additionally, I made sure that the final API URL does not contain a double slash, in case the `api:` field in `contest.yaml` already ends with a slash.