### PR TITLE
Fix #134: Testsession lettering from end of alphabet

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/bin/contest.py
+++ b/bin/contest.py
@@ -33,12 +33,6 @@ def contest_yaml():
     return _contest_yaml
 
 
-def next_label(label):
-    if label is None:
-        return 'X' if (contest_yaml() or {}).get('testsession') else 'A'
-    return label[:-1] + chr(ord(label[-1]) + 1)
-
-
 _problems_yaml = None
 
 

--- a/bin/contest.py
+++ b/bin/contest.py
@@ -35,7 +35,7 @@ def contest_yaml():
 
 def next_label(label):
     if label is None:
-        return 'A'
+        return 'X' if (contest_yaml() or {}).get('testsession') else 'A'
     return label[:-1] + chr(ord(label[-1]) + 1)
 
 

--- a/bin/contest.py
+++ b/bin/contest.py
@@ -17,7 +17,7 @@ def contest_yaml():
     if _contest_yaml:
         return _contest_yaml
     if _contest_yaml is False:
-        return None
+        return {}
 
     path = None
     # TODO: Do we need both here?
@@ -28,9 +28,9 @@ def contest_yaml():
             break
     if path is None:
         _contest_yaml = False
-        return None
+        return {}
     _contest_yaml = read_yaml_settings(path)
-    return _contest_yaml
+    return _contest_yaml or {}
 
 
 _problems_yaml = None
@@ -52,13 +52,11 @@ def problems_yaml():
 
 
 def get_api():
-    api = config.args.api
+    api = config.args.api or contest_yaml().get('api')
     if not api:
-        if contest_yaml() is None or 'api' not in contest_yaml():
-            fatal(
-                'Could not find key `api` in contest.yaml and it was not specified on the command line.'
-            )
-        api = contest_yaml()['api']
+        fatal(
+            'Could not find key `api` in contest.yaml and it was not specified on the command line.'
+        )
     if not api.endswith('/'):
         api += '/'
     api += 'api/v4'
@@ -68,7 +66,7 @@ def get_api():
 def get_contest_id():
     if config.args.contest_id:
         return config.args.contest_id
-    if contest_yaml() and contest_yaml().get('contest_id'):
+    if 'contest_id' in contest_yaml():
         return contest_yaml()['contest_id']
     url = f'{get_api()}/contests'
     verbose(f'query {url}')

--- a/bin/export.py
+++ b/bin/export.py
@@ -228,8 +228,8 @@ def update_contest_id(cid):
 
 
 def export_contest(problems):
-    if contest_yaml() is None:
-        fatal('Exporting a contest only works if contest.yaml is available.')
+    if not contest_yaml():
+        fatal('Exporting a contest only works if contest.yaml is available and not empty.')
 
     try:
         r = call_api(
@@ -319,8 +319,8 @@ def update_problems_yaml(problems):
 
 
 def export_problems(problems, cid):
-    if contest_yaml() is None:
-        fatal('Exporting a contest only works if contest.yaml is available.')
+    if not contest_yaml():
+        fatal('Exporting a contest only works if contest.yaml is available and not empty.')
 
     update_problems_yaml(problems)
 

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -80,21 +80,13 @@ def prepare_problem(problem):
     create_samples_file(problem)
 
 
-_contest_settings = None
-
-
 def get_tl(problem):
     problem_config = problem.settings
     tl = problem_config.timelimit
     tl = int(tl) if abs(tl - int(tl)) < 0.0001 else tl
 
-    global _contest_settings
-    if _contest_settings is None:
-        _contest_settings = contest_yaml()
-
-    print_tl = True
-    if 'print_timelimit' in _contest_settings:
-        print_tl = _contest_settings['print_timelimit']
+    if 'print_timelimit' in contest_yaml():
+        print_tl = contest_yaml()['print_timelimit']
     elif hasattr(config.args, 'no_timelimit'):
         print_tl = not config.args.no_timelimit
     else:

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -90,7 +90,7 @@ def get_tl(problem):
 
     global _contest_settings
     if _contest_settings is None:
-        _contest_settings = util.read_yaml_settings(Path('contest.yaml'))
+        _contest_settings = contest_yaml()
 
     print_tl = True
     if 'print_timelimit' in _contest_settings:
@@ -221,7 +221,7 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
         'testsession': '',
         'blank_page_text': '',
     }
-    config_data = util.read_yaml_settings(Path('contest.yaml'))
+    config_data = contest_yaml() or {}
     for x in default_config_data:
         if x not in config_data:
             config_data[x] = default_config_data[x]

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -213,7 +213,7 @@ def build_contest_pdf(contest, problems, tmpdir, solutions=False, web=False):
         'testsession': '',
         'blank_page_text': '',
     }
-    config_data = contest_yaml() or {}
+    config_data = contest_yaml()
     for x in default_config_data:
         if x not in config_data:
             config_data[x] = default_config_data[x]
@@ -270,7 +270,7 @@ def generate_solvestats(problems):
     solve_stats_dir = Path('solve_stats').resolve()
     problem_stats = Path('solve_stats/problem_stats.tex')
     solve_stats_dir.mkdir(exist_ok=True)
-    scoreboard_repo = config.args.scoreboard_repo or contest_yaml().get('scoreboard_repo', None)
+    scoreboard_repo = config.args.scoreboard_repo or contest_yaml().get('scoreboard_repo')
     if not scoreboard_repo:
         fatal('scoreboard_repo must be set in contest.yaml or passed as an argument')
     scoreboard_repo = Path(scoreboard_repo).expanduser()

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -146,7 +146,12 @@ def new_problem():
             ryaml.default_flow_style = False
             ryaml.indent(mapping=2, sequence=4, offset=2)
             data = ryaml.load(problems_yaml) or []
-            next_label = contest.next_label(data[-1]['label'] if data else None)
+            prev_label = data[-1]['label'] if data else None
+            next_label = (
+                ('X' if (contest.contest_yaml() or {}).get('testsession') else 'A')
+                if prev_label is None
+                else prev_label[:-1] + chr(ord(prev_label[-1]) + 1)
+            )
             # Name and timelimits are overridden by problem.yaml, but still required.
             data.append(
                 {

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -116,7 +116,7 @@ def new_problem():
         validation = _ask_variable('validation (default/custom/custom interactive)', 'default')
 
     # Read settings from the contest-level yaml file.
-    variables = contest.contest_yaml() or {}
+    variables = contest.contest_yaml()
     if 'source' not in variables:
         variables['source'] = variables.get('name', '')
 
@@ -148,7 +148,7 @@ def new_problem():
             data = ryaml.load(problems_yaml) or []
             prev_label = data[-1]['label'] if data else None
             next_label = (
-                ('X' if (contest.contest_yaml() or {}).get('testsession') else 'A')
+                ('X' if contest.contest_yaml().get('testsession') else 'A')
                 if prev_label is None
                 else prev_label[:-1] + chr(ord(prev_label[-1]) + 1)
             )

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -116,7 +116,7 @@ def new_problem():
         validation = _ask_variable('validation (default/custom/custom interactive)', 'default')
 
     # Read settings from the contest-level yaml file.
-    variables = read_yaml_settings(Path('contest.yaml'))
+    variables = contest.contest_yaml() or {}
     if 'source' not in variables:
         variables['source'] = variables.get('name', '')
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -146,14 +146,16 @@ def get_problems():
             for shortname, label in problem_labels:
                 problems.append(Problem(Path(shortname), tmpdir, label))
         else:
-            # Otherwise, fallback to all directories with a problem.yaml and sort by
-            # shortname.
-            label_ord = 0
-            for path in glob(Path('.'), '*/'):
-                if is_problem_directory(path):
-                    label = chr(ord('A') + label_ord)
-                    problems.append(Problem(path, tmpdir, label))
-                    label_ord += 1
+            # Otherwise, fallback to all directories with a problem.yaml and sort by shortname.
+            problem_paths = list(filter(is_problem_directory, glob(Path('.'), '*/')))
+            start_label_ord = (
+                ord('Z') - len(problem_paths) + 1
+                if (contest_yaml() or {}).get('testsession')
+                else ord('A')
+            )
+            for i, path in enumerate(problem_paths):
+                label = chr(start_label_ord + i)
+                problems.append(Problem(path, tmpdir, label))
             if len(problems) == 0:
                 fatal('Did not find problem.yaml. Are you running this from a problem directory?')
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -149,9 +149,7 @@ def get_problems():
             # Otherwise, fallback to all directories with a problem.yaml and sort by shortname.
             problem_paths = list(filter(is_problem_directory, glob(Path('.'), '*/')))
             start_label_ord = (
-                ord('Z') - len(problem_paths) + 1
-                if (contest_yaml() or {}).get('testsession')
-                else ord('A')
+                ord('Z') - len(problem_paths) + 1 if contest_yaml().get('testsession') else ord('A')
             )
             for i, path in enumerate(problem_paths):
                 label = chr(start_label_ord + i)


### PR DESCRIPTION
This fix consists of two parts:
- When running a command for the full contest (e.g., `bt pdf` in the contest root) while there is no `problems.yaml` file present.
  - In this case, start counting at chr(ord('Z') - len(problems) + 1).
- When calling `bt new_problem` with an empty `problems.yaml` file.
  - In this case, start counting at 'X'.