### PR TITLE
Fix #149: Remove indent from `ruamel.yaml` written `problems.yaml`

### DIFF
--- a/bin/skel.py
+++ b/bin/skel.py
@@ -160,9 +160,13 @@ def new_problem():
             ryaml.dump(
                 data,
                 problems_yaml,
-                # Remove spaces at the start of each line, caused by the indent configuration.
+                # Remove spaces at the start of each (non-commented) line, caused by the indent configuration.
                 # If there was a top-level key (like `problems:`), this wouldn't be needed...
-                transform=lambda yaml_str: "\n".join(line[2:] for line in yaml_str.split("\n")),
+                # See also: https://stackoverflow.com/a/58773229
+                transform=lambda yaml_str: "\n".join(
+                    line if line.strip().startswith('#') else line[2:]
+                    for line in yaml_str.split("\n")
+                ),
             )
         except NameError as e:
             error('ruamel.yaml library not found. Please update problems.yaml manually.')

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -157,7 +157,13 @@ def new_problem():
                     'timelimit': 1.0,
                 }
             )
-            ryaml.dump(data, problems_yaml)
+            ryaml.dump(
+                data,
+                problems_yaml,
+                # Remove spaces at the start of each line, caused by the indent configuration.
+                # If there was a top-level key (like `problems:`), this wouldn't be needed...
+                transform=lambda yaml_str: "\n".join(line[2:] for line in yaml_str.split("\n")),
+            )
         except NameError as e:
             error('ruamel.yaml library not found. Please update problems.yaml manually.')
 


### PR DESCRIPTION
The reason why ruamel.yaml adds two extra spaces at the start of each line, is the indent config (sequence=4, offset=2).
Either this indent config should be made inconsistent with the indent configs used on other places, or we post-process the yaml to remove the leading spaces (which I've done in this commit).