### PR TITLE
[config] Fix #132: Personal config file

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -58,13 +58,42 @@ os.environ["PATH"] += os.pathsep + str(tools_root / 'third_party')
 
 # Below here is some global state that will be filled in main().
 
-# Some default values needed for tests.
 args = argparse.Namespace()
-args.testcases = None
-args.cpp_flags = None
-args.verbose = None
-args.force_build = None
-args.error = None
+
+
+def set_default_args():
+    # Set default argument values
+    for arg in [
+        '1',
+        'add_manual',
+        'all',
+        'check_deterministic',
+        'clean',
+        'clean_generated',
+        'cpp_flags',
+        'contest_id',
+        'default_solution',
+        'ignore_validators',
+        'interaction',
+        'memory',
+        'move_manual',
+        'move_to',
+        'no_bar',
+        'no_generate',
+        'no_timelimit',
+        'order',
+        'order_from_ccs',
+        'remove',
+        'samples',
+        'scoreboard_repo',
+        'submissions',
+        'table',
+        'testcases',
+        'timeout',
+        'watch',
+    ]:
+        if not hasattr(args, arg):
+            setattr(args, arg, None)
 
 
 level = None

--- a/bin/config.py
+++ b/bin/config.py
@@ -71,65 +71,16 @@ default_args = {
 """
 for cmd in $(bapctools --help | grep '^  {' | sed 's/  {//;s/}//;s/,/ /g') ; do bapctools $cmd --help ; done |& \
 grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_/g' | sort -u | \
-grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/        '/;s/$/',/"
+grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
+# fmt: off
+args_list = ['1', 'add_manual', 'all', 'api', 'author', 'check_deterministic', 'clean', 'clean_generated', 'cleanup_generated', 'contest', 'contest_id', 'contestname', 'cp', 'cpp_flags', 'default_solution', 'directory', 'error', 'force', 'force_build', 'ignore_validators', 'input', 'interaction', 'interactive', 'kattis', 'memory', 'move_manual', 'move_to', 'no_bar', 'no_generate', 'no_solutions', 'no_timelimit', 'order', 'order_from_ccs', 'output', 'password', 'problem', 'problemname', 'remove', 'samples', 'scoreboard_repo', 'skel', 'skip', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'username', 'validation', 'watch', 'web']
+# fmt: on
 
 
 def set_default_args():
     # Set default argument values.
-    for arg in [
-        '1',
-        'add_manual',
-        'all',
-        'api',
-        'author',
-        'check_deterministic',
-        'clean',
-        'clean_generated',
-        'cleanup_generated',
-        'contest',
-        'contest_id',
-        'contestname',
-        'cp',
-        'cpp_flags',
-        'default_solution',
-        'directory',
-        'error',
-        'force',
-        'force_build',
-        'ignore_validators',
-        'input',
-        'interaction',
-        'interactive',
-        'kattis',
-        'memory',
-        'move_manual',
-        'move_to',
-        'no_bar',
-        'no_generate',
-        'no_solutions',
-        'no_timelimit',
-        'order',
-        'order_from_ccs',
-        'output',
-        'password',
-        'problem',
-        'problemname',
-        'remove',
-        'samples',
-        'scoreboard_repo',
-        'skel',
-        'skip',
-        'submissions',
-        'table',
-        'testcases',
-        'timelimit',
-        'timeout',
-        'username',
-        'validation',
-        'watch',
-        'web',
-    ]:
+    for arg in args_list:
         if not hasattr(args, arg):
             setattr(args, arg, None)
     for arg, value in default_args.items():

--- a/bin/config.py
+++ b/bin/config.py
@@ -62,7 +62,7 @@ args = argparse.Namespace()
 
 default_args = {
     'jobs': os.cpu_count() // 2,
-    'time': 600,
+    'time': 600,  # Used for `bt fuzz`
     'verbose': 0,
 }
 

--- a/bin/config.py
+++ b/bin/config.py
@@ -75,13 +75,6 @@ n_error = 0
 n_warn = 0
 
 
-# Return the command line timeout or the default of 30 seconds.
-def timeout():
-    if hasattr(args, 'timeout'):
-        return args.timeout
-    return 30
-
-
 # Set to true when running as a test.
 RUNNING_TEST = False
 TEST_TLE_SUBMISSIONS = False

--- a/bin/config.py
+++ b/bin/config.py
@@ -67,21 +67,33 @@ default_args = {
 }
 
 
+# The list of arguments below is generated using the following command:
+"""
+for cmd in $(bapctools --help | grep '^  {' | sed 's/  {//;s/}//;s/,/ /g') ; do bapctools $cmd --help ; done |& \
+grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_/g' | sort -u | \
+grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/        '/;s/$/',/"
+"""
+
+
 def set_default_args():
-    # Set default argument values
+    # Set default argument values.
     for arg in [
         '1',
         'add_manual',
         'all',
+        'api',
+        'author',
         'check_deterministic',
         'clean',
         'clean_generated',
         'cleanup_generated',
-        'cp',
-        'cpp_flags',
         'contest',
         'contest_id',
+        'contestname',
+        'cp',
+        'cpp_flags',
         'default_solution',
+        'directory',
         'error',
         'force',
         'force_build',
@@ -100,7 +112,9 @@ def set_default_args():
         'order',
         'order_from_ccs',
         'output',
+        'password',
         'problem',
+        'problemname',
         'remove',
         'samples',
         'scoreboard_repo',
@@ -111,6 +125,8 @@ def set_default_args():
         'testcases',
         'timelimit',
         'timeout',
+        'username',
+        'validation',
         'watch',
         'web',
     ]:

--- a/bin/config.py
+++ b/bin/config.py
@@ -60,6 +60,12 @@ os.environ["PATH"] += os.pathsep + str(tools_root / 'third_party')
 
 args = argparse.Namespace()
 
+default_args = {
+    'jobs': os.cpu_count() // 2,
+    'time': 600,
+    'verbose': 0,
+}
+
 
 def set_default_args():
     # Set default argument values
@@ -70,30 +76,49 @@ def set_default_args():
         'check_deterministic',
         'clean',
         'clean_generated',
+        'cleanup_generated',
+        'cp',
         'cpp_flags',
+        'contest',
         'contest_id',
         'default_solution',
+        'error',
+        'force',
+        'force_build',
         'ignore_validators',
+        'input',
         'interaction',
+        'interactive',
+        'kattis',
         'memory',
         'move_manual',
         'move_to',
         'no_bar',
         'no_generate',
+        'no_solutions',
         'no_timelimit',
         'order',
         'order_from_ccs',
+        'output',
+        'problem',
         'remove',
         'samples',
         'scoreboard_repo',
+        'skel',
+        'skip',
         'submissions',
         'table',
         'testcases',
+        'timelimit',
         'timeout',
         'watch',
+        'web',
     ]:
         if not hasattr(args, arg):
             setattr(args, arg, None)
+    for arg, value in default_args.items():
+        if not hasattr(args, arg):
+            setattr(args, arg, value)
 
 
 level = None

--- a/bin/constraints.py
+++ b/bin/constraints.py
@@ -15,7 +15,7 @@ from util import *
 """
 
 
-def check_constraints(problem, settings):
+def check_constraints(problem):
     in_constraints = {}
     ans_constraints = {}
     problem.validate_format('input_format', constraints=in_constraints)

--- a/bin/export.py
+++ b/bin/export.py
@@ -81,7 +81,7 @@ def build_samples_zip(problems):
     print("Wrote zip to samples.zip", file=sys.stderr)
 
 
-def build_problem_zip(problem, output, settings):
+def build_problem_zip(problem, output):
     """Make DOMjudge ZIP file for specified problem."""
 
     if not problem.interactive:
@@ -119,7 +119,7 @@ def build_problem_zip(problem, output, settings):
             ('attachments/**/*', False),
         ]
 
-    if 'custom' in settings.validation:
+    if 'custom' in problem.settings.validation:
         files.append(('output_validators/**/*', True))
 
     if config.args.kattis:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1364,7 +1364,7 @@ class GeneratorConfig:
                         not isinstance(yaml[d.path.name], ruamel.yaml.comments.CommentedMap)
                         or yaml[d.path.name].get('type') != 'directory'
                     ):
-                        fatal_error(f'Can not overwrite yaml key for {d.path} with a directory.')
+                        fatal(f'Can not overwrite yaml key for {d.path} with a directory.')
                 else:
                     yaml[d.path.name] = {'type': 'directory', 'data': None}
             elif isinstance(yaml, ruamel.yaml.comments.CommentedSeq):

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -90,10 +90,8 @@ def get_tl(problem):
 
     if 'print_timelimit' in contest_yaml():
         print_tl = contest_yaml()['print_timelimit']
-    elif config.args.no_timelimit is not None:
-        print_tl = not config.args.no_timelimit
     else:
-        print_tl = True
+        print_tl = not config.args.no_timelimit
 
     return tl if print_tl else ''
 

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -90,7 +90,7 @@ def get_tl(problem):
 
     if 'print_timelimit' in contest_yaml():
         print_tl = contest_yaml()['print_timelimit']
-    elif hasattr(config.args, 'no_timelimit'):
+    elif config.args.no_timelimit is not None:
         print_tl = not config.args.no_timelimit
     else:
         print_tl = True

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -107,17 +107,9 @@ class Problem:
         self.settings = argparse.Namespace(**self.settings)
 
         # Override settings by command line arguments.
-        try:
-            self.settings.timelimit = config.args.timelimit or self.settings.timelimit
-        except AttributeError:
-            pass
+        self.settings.timelimit = config.args.timelimit or self.settings.timelimit
 
-        timeout = 1.5 * self.settings.timelimit + 1
-        try:
-            if config.args.timeout:
-                timeout = config.args.timeout
-        except AttributeError:
-            pass
+        timeout = config.args.timeout or 1.5 * self.settings.timelimit + 1
         self.settings.timeout = int(timeout)
 
         if self.settings.validation not in config.VALIDATION_MODES:
@@ -155,11 +147,8 @@ class Problem:
             return x.copy() if copy and isinstance(x, (list, dict)) else x
 
         samplesonly = only_sample
-        try:
-            if config.args.samples:
-                samplesonly = True
-        except AttributeError:
-            pass
+        if config.args.samples:
+            samplesonly = True
 
         if p.interactive:
             needans = False
@@ -459,7 +448,7 @@ class Problem:
                 needs_leading_newline = not printed_newline
                 ok &= submission_ok
 
-        if hasattr(config.args, 'table') and config.args.table:
+        if config.args.table:
             Problem._print_table(verdict_table, testcases, submissions)
 
         return ok
@@ -629,7 +618,7 @@ class Problem:
     # This function will always raise a warning.
     # Which submission is used is implementation defined, unless one is explicitly given on the command line.
     def default_solution_path(problem):
-        if hasattr(config.args, 'default_solution') and config.args.default_solution:
+        if config.args.default_solution:
             fixed = True
             solution = problem.path / config.args.default_solution
         else:

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -108,9 +108,7 @@ class Problem:
 
         # Override settings by command line arguments.
         self.settings.timelimit = config.args.timelimit or self.settings.timelimit
-
-        timeout = config.args.timeout or 1.5 * self.settings.timelimit + 1
-        self.settings.timeout = int(timeout)
+        self.settings.timeout = int(config.args.timeout or 1.5 * self.settings.timelimit + 1)
 
         if self.settings.validation not in config.VALIDATION_MODES:
             fatal(
@@ -146,9 +144,7 @@ class Problem:
         def maybe_copy(x):
             return x.copy() if copy and isinstance(x, (list, dict)) else x
 
-        samplesonly = only_sample
-        if config.args.samples:
-            samplesonly = True
+        samplesonly = config.args.samples or only_sample
 
         if p.interactive:
             needans = False

--- a/bin/program.py
+++ b/bin/program.py
@@ -419,10 +419,6 @@ class Program:
             problem._program_callbacks[path] = []
         problem._program_callbacks[path].append(c)
 
-    @staticmethod
-    def timeout():
-        return config.args.timeout or 30
-
 
 class Generator(Program):
     subdir = 'generators'
@@ -445,16 +441,18 @@ class Generator(Program):
             else:
                 f.unlink()
 
+        timeout = config.args.timeout or 30
+
         with stdout_path.open('w') as stdout_file:
             result = exec_command(
-                self.run_command + args, stdout=stdout_file, timeout=Program.timeout(), cwd=cwd
+                self.run_command + args, stdout=stdout_file, timeout=timeout, cwd=cwd
             )
 
         result.retry = False
 
         if result.ok == -9:
             # Timeout -> stop retrying and fail.
-            bar.error(f'TIMEOUT after {Program.timeout()}s')
+            bar.error(f'TIMEOUT after {timeout}s')
             return result
 
         if result.ok is not True:
@@ -483,4 +481,4 @@ class Visualizer(Program):
     # Stdin and stdout are not used.
     def run(self, cwd, args=[]):
         assert self.run_command is not None
-        return exec_command(self.run_command + args, timeout=Program.timeout(), cwd=cwd)
+        return exec_command(self.run_command + args, timeout=config.args.timeout or 30, cwd=cwd)

--- a/bin/program.py
+++ b/bin/program.py
@@ -419,6 +419,10 @@ class Program:
             problem._program_callbacks[path] = []
         problem._program_callbacks[path].append(c)
 
+    @staticmethod
+    def timeout():
+        return config.args.timeout or 30
+
 
 class Generator(Program):
     subdir = 'generators'
@@ -443,14 +447,14 @@ class Generator(Program):
 
         with stdout_path.open('w') as stdout_file:
             result = exec_command(
-                self.run_command + args, stdout=stdout_file, timeout=config.timeout(), cwd=cwd
+                self.run_command + args, stdout=stdout_file, timeout=Program.timeout(), cwd=cwd
             )
 
         result.retry = False
 
         if result.ok == -9:
             # Timeout -> stop retrying and fail.
-            bar.error(f'TIMEOUT after {config.timeout()}s')
+            bar.error(f'TIMEOUT after {Program.timeout()}s')
             return result
 
         if result.ok is not True:
@@ -479,4 +483,4 @@ class Visualizer(Program):
     # Stdin and stdout are not used.
     def run(self, cwd, args=[]):
         assert self.run_command is not None
-        return exec_command(self.run_command + args, timeout=config.timeout(), cwd=cwd)
+        return exec_command(self.run_command + args, timeout=Program.timeout(), cwd=cwd)

--- a/bin/run.py
+++ b/bin/run.py
@@ -146,7 +146,7 @@ class Testcase:
                 continue
 
             # Move testcase to destination directory if specified.
-            if hasattr(config.args, 'move_to') and config.args.move_to:
+            if config.args.move_to:
                 infile = self.in_path
                 targetdir = self.problem.path / config.args.move_to
                 targetdir.mkdir(parents=True, exist_ok=True)
@@ -160,11 +160,7 @@ class Testcase:
                     bar.log('Moved to ' + print_name(anstarget))
 
             # Remove testcase if specified.
-            elif (
-                validator_type == 'input_format'
-                and hasattr(config.args, 'remove')
-                and config.args.remove
-            ):
+            elif validator_type == 'input_format' and config.args.remove:
                 bar.log(Fore.RED + 'REMOVING TESTCASE!' + Style.RESET_ALL)
                 if self.in_path.exists():
                     self.in_path.unlink()

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -50,14 +50,14 @@ def alpha_num(string):
     return s
 
 
-def new_contest(name):
+def new_contest():
     if config.args.contest:
         fatal('--contest does not work for new_contest.')
     if config.args.problem:
         fatal('--problem does not work for new_contest.')
 
     # Ask for all required infos.
-    title = _ask_variable('name', name)
+    title = _ask_variable('name', config.args.contestname)
     subtitle = _ask_variable('subtitle', '').replace('_', '-')
     dirname = _ask_variable('dirname', _alpha_num(title))
     author = _ask_variable('author', f'The {title} jury').replace('_', '-')

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -681,18 +681,24 @@ def run_parsed_arguments(args):
         'clean_generated',
         'cpp_flags',
         'contest_id',
+        'default_solution',
         'ignore_validators',
         'interaction',
+        'memory',
         'move_manual',
-        'move_manual',
+        'move_to',
+        'no_bar',
         'no_generate',
+        'no_timelimit',
         'order',
         'order_from_ccs',
+        'remove',
         'samples',
         'scoreboard_repo',
         'submissions',
         'table',
         'testcases',
+        'timeout',
         'watch',
     ]:
         if not hasattr(config.args, arg):
@@ -791,7 +797,7 @@ def run_parsed_arguments(args):
         if (
             level == 'problemset'
             and action in ['pdf', 'export', 'update_problems_yaml']
-            and not (hasattr(config.args, 'all') and config.args.all)
+            and not config.args.all
         ):
             continue
         print(Style.BRIGHT, 'PROBLEM ', problem.name, Style.RESET_ALL, sep='', file=sys.stderr)
@@ -806,10 +812,6 @@ def run_parsed_arguments(args):
             config.args.add_manual = False
             config.args.move_manual = False
             config.args.verbose = 0
-            if not hasattr(config.args, 'testcases'):
-                config.args.testcases = None
-            if not hasattr(config.args, 'force'):
-                config.args.force = False
             success &= generate.generate(problem)
             config.args = old_args
         if action in ['fuzz']:
@@ -817,9 +819,7 @@ def run_parsed_arguments(args):
         if action in ['pdf', 'all']:
             # only build the pdf on the problem level, or on the contest level when
             # --all is passed.
-            if level == 'problem' or (
-                level == 'problemset' and hasattr(config.args, 'all') and config.args.all
-            ):
+            if level == 'problem' or (level == 'problemset' and config.args.all):
                 success &= latex.build_problem_pdf(problem)
         if action in ['solutions']:
             if level == 'problem':
@@ -845,7 +845,7 @@ def run_parsed_arguments(args):
 
                 # Set up arguments for generate.
                 old_args = argparse.Namespace(**vars(config.args))
-                config.args.check_deterministic = False if config.args.force else True
+                config.args.check_deterministic = not config.args.force
                 config.args.jobs = None
                 config.args.add_manual = False
                 config.args.move_manual = False

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -711,7 +711,7 @@ def run_parsed_arguments(args):
 
     # Skel commands.
     if action in ['new_contest']:
-        skel.new_contest(config.args.contestname)
+        skel.new_contest()
         return
 
     if action in ['new_problem']:
@@ -796,9 +796,6 @@ def run_parsed_arguments(args):
             continue
         print(Style.BRIGHT, 'PROBLEM ', problem.name, Style.RESET_ALL, sep='', file=sys.stderr)
 
-        # TODO: Remove usages of settings.
-        settings = problem.settings
-
         if action in ['generate']:
             success &= generate.generate(problem)
         if action in ['all', 'constraints', 'run'] and not config.args.no_generate:
@@ -839,7 +836,7 @@ def run_parsed_arguments(args):
             config.args.no_bar = True
             success &= problem.test_submissions()
         if action in ['constraints']:
-            success &= constraints.check_constraints(problem, settings)
+            success &= constraints.check_constraints(problem)
         if action in ['zip']:
             output = problem.path.with_suffix('.zip')
 
@@ -865,7 +862,7 @@ def run_parsed_arguments(args):
 
                 # Write to problemname.zip, where we strip all non-alphanumeric from the
                 # problem directory name.
-                success &= export.build_problem_zip(problem, output, settings)
+                success &= export.build_problem_zip(problem, output)
         if action == 'all' and config.args.cleanup_generated:
             success &= generate.cleanup_generated(problem)
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -780,7 +780,7 @@ def run_parsed_arguments(args):
 
     if action == 'solvestats':
         if level == 'problem':
-            fatal_error('solvestats only works for a contest')
+            fatal('solvestats only works for a contest')
         latex.generate_solvestats(problems)
         return
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -509,7 +509,6 @@ Run this from one of:
     )
 
     # Fuzzer
-    # TODO: Also allow specifying a list of submissions?
     fuzzparser = subparsers.add_parser(
         'fuzz',
         parents=[global_parser],

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -318,7 +318,7 @@ Run this from one of:
         '--jobs',
         '-j',
         type=int,
-        help='The number of jobs to use. Default is cpu_count()/2.',
+        help='The number of jobs to use. Default: cpu_count()/2.',
     )
     global_parser.add_argument(
         '--api',
@@ -468,7 +468,7 @@ Run this from one of:
         help='Rerun all generators to make sure generators are deterministic.',
     )
     genparser.add_argument(
-        '--timeout', '-t', type=int, help='Override the default timeout (Default: 30).'
+        '--timeout', '-t', type=int, help='Override the default timeout. Default: 30.'
     )
     genparser.add_argument(
         '--samples',
@@ -557,13 +557,13 @@ Run this from one of:
     runparser.add_argument(
         '--timeout',
         type=int,
-        help='Override the default timeout (Default: 1.5 * timelimit + 1).',
+        help='Override the default timeout. Default: 1.5 * timelimit + 1.',
     )
     runparser.add_argument('--timelimit', '-t', type=int, help='Override the default timelimit.')
     runparser.add_argument(
         '--memory',
         '-m',
-        help='The max amount of memory in MB a subprocesses may use. Does not work for java. (Default: 2048)',
+        help='The max amount of memory in MB a subprocesses may use. Does not work for java. Default: 2048.',
     )
     runparser.add_argument(
         '--force',
@@ -595,12 +595,12 @@ Run this from one of:
     testparser.add_argument(
         '--timeout',
         type=int,
-        help='Override the default timeout (Default: 1.5 * timelimit + 1).',
+        help='Override the default timeout. Default: 1.5 * timelimit + 1.',
     )
     testparser.add_argument(
         '--memory',
         '-m',
-        help='The max amount of memory in MB a subprocesses may use. Does not work for java. (Default: 2048)',
+        help='The max amount of memory in MB a subprocesses may use. Does not work for java. Default: 2048.',
     )
 
     # Sort
@@ -908,8 +908,7 @@ def read_personal_config():
     ]:
         if not config_file.is_file():
             continue
-        config_data = read_yaml(config_file)
-        assert isinstance(config_data, dict)
+        config_data = read_yaml(config_file) or {}
         for arg, value in config_data.items():
             if arg not in args:
                 args[arg] = value

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -670,39 +670,7 @@ Run this from one of:
 def run_parsed_arguments(args):
     # Process arguments
     config.args = args
-
-    # Set default argument values
-    for arg in [
-        '1',
-        'add_manual',
-        'all',
-        'check_deterministic',
-        'clean',
-        'clean_generated',
-        'cpp_flags',
-        'contest_id',
-        'default_solution',
-        'ignore_validators',
-        'interaction',
-        'memory',
-        'move_manual',
-        'move_to',
-        'no_bar',
-        'no_generate',
-        'no_timelimit',
-        'order',
-        'order_from_ccs',
-        'remove',
-        'samples',
-        'scoreboard_repo',
-        'submissions',
-        'table',
-        'testcases',
-        'timeout',
-        'watch',
-    ]:
-        if not hasattr(config.args, arg):
-            setattr(config.args, arg, None)
+    config.set_default_args()
 
     action = config.args.action
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -147,7 +147,7 @@ class ProgressBar:
         self.item_width = max(self.item_width, ProgressBar.item_len(item))
 
     def clearline(self):
-        if hasattr(config.args, 'no_bar') and config.args.no_bar:
+        if config.args.no_bar:
             return
         assert self.lock.locked()
         print(self.carriage_return, end='', flush=True, file=sys.stderr)
@@ -626,12 +626,11 @@ def crop_output(output):
 # Return memory limit in MB.
 def get_memory_limit(kwargs=None):
     memory_limit = 2048  # 2GB
-    if hasattr(config.args, 'memory'):
-        if config.args.memory:
-            if config.args.memory != 'unlimited':
-                memory_limit = int(config.args.memory)
-            else:
-                memory_limit = None  # disabled
+    if config.args.memory:
+        if config.args.memory != 'unlimited':
+            memory_limit = int(config.args.memory)
+        else:
+            memory_limit = None  # disabled
     if kwargs and 'memory' in kwargs:
         memory_limit = kwargs['memory']
         kwargs.pop('memory')

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -14,7 +14,7 @@ This lists all subcommands and their most important options.
 - Problem development:
   - [`bt run [-v] [-t TIMELIMIT] [-m MEMORY] [--force] [submissions [submissions ...]] [testcases [testcases ...]]`](#run)
   - [`bt test [-v] [-t TIMEOUT] [-m MEMORY] submission [--interactive | --samples | [testcases [testcases ...]]]`](#test)
-  - [`bt generate [-v] [-t TIMEOUT] [--force [--samples]] [--all] [--check_deterministic] [--add-manual] [--move-manual [DIRECTORY]] [--clean] [--clean-generated] [--jobs JOBS] [testcases [testcases ...]]`](#generate)
+  - [`bt generate [-v] [-t TIMEOUT] [--force [--samples]] [--all] [--check-deterministic] [--add-manual] [--move-manual [DIRECTORY]] [--clean] [--clean-generated] [--jobs JOBS] [testcases [testcases ...]]`](#generate)
   - [`bt pdf [-v] [--all] [--web] [--cp] [--no-timelimit]`](#pdf)
   - [`bt solutions [-v] [--web] [--cp] [--order ORDER]`](#solutions)
   - [`bt stats`](#stats)
@@ -46,8 +46,8 @@ The flags below work for any subcommand:
 - `--problem <directory>`: The directory of the problem to use, if not the current directory. At most one of `--contest` and `--problem` may be used. Useful in CI jobs.
 - `--no-bar`: Disable showing progress bars. This is useful when running in non-interactive contexts (such as CI jobs) or on platforms/terminals that don't handle the progress bars well.
 - `--error`/`-e`: show full output of failing commands using `--error`. The default is to show a short snippet only.
-- `--cpp_flags`: Additional flags to pass to any C++ compilation rule. Useful for e.g. `--cpp_flags=-fsanitize=undefined`.
-- `--force_build`: Force rebuilding binaries instead of reusing cached version.
+- `--cpp-flags`: Additional flags to pass to any C++ compilation rule. Useful for e.g. `--cpp-flags=-fsanitize=undefined`.
+- `--force-build`: Force rebuilding binaries instead of reusing cached version.
 
 # Problem development
 
@@ -62,7 +62,7 @@ bt run [<submissions and/or testcases>]
 
 This first makes sure all generated testcases are up to date and then runs the given submissions (or all submissions by default) against the given testcases (or all testcases by default).
 
-By default this prints one summary line per submission containing the slowest testcase.
+By default, this prints one summary line per submission containing the slowest testcase.
 If the submission failed, it also prints the testcases for which it failed.
 Use `bt run -v` to show results for all testcases.
 
@@ -153,7 +153,7 @@ Pass a list of testcases or directories to only generate a subset of data. See [
 - `--force`/`-f`: By default, `generate` will not overwrite any files, but instead warn that they will change. Pass `--force` to overwrite existing files.
 - `--samples`: Even with `--force`, samples won't be overwritten by default. `--force --samples` also overwrites samples. (Samples usually have a manually curated input and output that should not be overwritten easily.)
 - `--all`/`-a`: Fully regenerate all test cases, skipping the up-to-date check.
-- `--check_deterministic`: Check that the .in files are generated deterministically for all test cases, skipping the up-to-date check. This is implicitly set to true for `bt all`.
+- `--check-deterministic`: Check that the .in files are generated deterministically for all test cases, skipping the up-to-date check. This is implicitly set to true for `bt all`.
 - `--add-manual`: Testcases and directories in `data/` that do not have a corresponding entry in `generators.yaml` are automatically added.
 - `--move-manual [directory]`: Move all inline testcases to the specified directory (which defaults to `generators/manual`) and update `generators.yaml`. Implies `--add-manual`.
 - `--clean`: Delete all files/testcases not listed in `generators.yaml`. Without `-f`, this does a dry-run.

--- a/readme.md
+++ b/readme.md
@@ -161,9 +161,9 @@ This can also be used to create the contest pdf by running it from the contest d
 
 For some command-line flags, it is convenient if they are always set to the same value, which differs per user
 (e.g., `--username` or `--password` for commands that access a CCS like DOMjudge,
-or `--scoreboard_repo` for the `bt solvestats` command).
+or `--scoreboard-repo` for the `bt solvestats` command).
 For this, you can create a configuration YAML file containing key-value pairs
-in one of the following locations:
+in one of the following locations, from low to high priority:
 - `$XDG_CONFIG_HOME/bapctools/config.yaml` (Unix-ish systems, where `$XDG_CONFIG_HOME` usually is `~/.config`)
 - `%AppData%/bapctools/config.yaml` (Windows systems)
 - `<contest directory>/.bapctools.yaml`

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,21 @@ Use this command to compile the `problem.pdf` from the `problem_statement/proble
 
 This can also be used to create the contest pdf by running it from the contest directory.
 
+## Personal configuration file
+
+For some command-line flags, it is convenient if they are always set to the same value, which differs per user
+(e.g., `--username` or `--password` for commands that access a CCS like DOMjudge,
+or `--scoreboard_repo` for the `bt solvestats` command).
+For this, you can create a configuration YAML file containing key-value pairs
+in one of the following locations:
+- `$XDG_CONFIG_HOME/bapctools/config.yaml` (Unix-ish systems, where `$XDG_CONFIG_HOME` usually is `~/.config`)
+- `%AppData%/bapctools/config.yaml` (Windows systems)
+- `<contest directory>/.bapctools.yaml`
+
+The keys in this config file can be any option that can be passed on the command-line.
+Note that the keys should be written out in full (e.g., `username: jury` rather than `u: jury`)
+and any hyphens should be replaced with an underscore (e.g., `no_bar: True` rather than `no-bar: True`).
+
 ## Contributing / Style guide
 
 - The python code in the repository is formatted using [black](https://github.com/psf/black).

--- a/test/test_default_output_validator.py
+++ b/test/test_default_output_validator.py
@@ -18,6 +18,7 @@ DEFAULT_OUTPUT_VALIDATORS = ['default_output_validator.cpp']
 
 config.args.verbose = 2
 config.args.error = True
+config.set_default_args()
 
 # return list of (flags, ans, out, expected result)
 def read_tests():

--- a/test/test_generators_yaml.py
+++ b/test/test_generators_yaml.py
@@ -7,6 +7,7 @@ import generate
 import config
 
 config.RUNNING_TEST = True
+config.set_default_args()
 
 
 class MockProblem:


### PR DESCRIPTION
Fixes #132.

This PR adds the ability to have a personal config file, located at `$XDG_CONFIG_HOME/bapctools/config.yaml`¹ or `$CONTEST_DIR/.bapctools.yaml`². The keys in this config file can be any option that can be passed on the command-line. Note that the keys should be written out in full (e.g., `username:` rather than `u:`) and any hyphens should be replaced with an underscore (e.g., `no_bar:` rather than `no-bar:`)³.

In preparation for this PR, I have made sure that all `config.args` are read consistently in the same way, being "the value is `None` if it is not set" (i.e., `hasattr` or `key in args` checks are no longer necessary). Three keys have a different default value than `None`, listed in `config.default_args`.

Additionally, I made sure that the `args` object returned by the argument parser _only_ contains the keys set on the command line, using [`argument_default=SUPPRESS`](https://stackoverflow.com/a/62789053). Among other things, this means that `store_true` flags no longer set to `False` in the `args` object by default. Because of this, the function that reads the personal config file(s) can confidently check which values are set on the command line, so that other keys can use values from the personal configuration file(s) or the default value, in that order. This results in the following priority order for arguments (from low to high):

```
default value
$XDG_CONFIG_HOME/bapctools/config.yaml
$CONTEST_DIR/.bapctools.yaml
command line flag value
```

TODO:
- [ ] @RagnarGrootKoerkamp I added a short description of this feature to `readme.md`, but perhaps it would also be good to add something to `doc/implementation_notes.md`, but I am not sure what would be the best place for that :stuck_out_tongue: 

¹) On Unix-ish machines, this defaults to `~/.config`. On Windows machines, we use `%AppData%` instead.
²) Note that, because the personal config file(s) are queried before `cd`-ing to the contest's root directory, placing a `.bapctools.yaml` file in a problem directory will also work, but only when running a command directly from this problem directory.
³) `argparse` automatically converts hyphens to underscores, which automatically means that keys in the personal config file should all use underscores as well. Note that, currently, some command-line arguments use hyphens, while others use underscores. We might want to make that consistent (but I'm not sure in which direction) :stuck_out_tongue: