### PR TITLE
[util] Consistent writing of YAML files

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -253,62 +253,62 @@ def export_contest(problems):
 
 def update_problems_yaml(problems):
     # Update name and timelimit values.
-    log('Updating problems.yaml')
-    if has_ryaml:
-        path = Path('problems.yaml')
-        data = read_yaml(path) if path.is_file() else []
-
-        change = False
-        for problem in problems:
-            found = False
-            for d in data:
-                if d['id'] == problem.name:
-                    found = True
-                    if problem.settings.name and problem.settings.name != d.get('name'):
-                        change = True
-                        d['name'] = problem.settings.name
-
-                    if 'rgb' not in d:
-                        change = True
-                        d['rgb'] = "#000000"
-
-                    if (
-                        not problem.settings.timelimit_is_default
-                        and problem.settings.timelimit != d.get('time_limit')
-                    ):
-                        change = True
-                        d['time_limit'] = problem.settings.timelimit
-                    break
-            if not found:
-                change = True
-                log(f'Add problem {problem.name}')
-                data.append(
-                    {
-                        'id': problem.name,
-                        'label': problem.label,
-                        'name': problem.settings.name,
-                        'rgb': '#000000',
-                        'time_limit': problem.settings.timelimit,
-                    }
-                )
-
-        if change:
-            if config.args.action in ['update_problems_yaml']:
-                a = 'y'
-            else:
-                log('Update problems.yaml with latest values? [Y/n]')
-                a = input().lower()
-            if a == '' or a[0] == 'y':
-                write_yaml(data, path)
-                log(f'Updated problems.yaml')
-        else:
-            if config.args.action == 'update_problems_yaml':
-                log(f'Already up to date')
-
-    else:
+    if not has_ryaml:
         log(
             'ruamel.yaml library not found. Make sure to update the name and timelimit fields manually.'
         )
+        return
+
+    log('Updating problems.yaml')
+    path = Path('problems.yaml')
+    data = read_yaml(path) if path.is_file() else []
+
+    change = False
+    for problem in problems:
+        found = False
+        for d in data:
+            if d['id'] == problem.name:
+                found = True
+                if problem.settings.name and problem.settings.name != d.get('name'):
+                    change = True
+                    d['name'] = problem.settings.name
+
+                if 'rgb' not in d:
+                    change = True
+                    d['rgb'] = "#000000"
+
+                if (
+                    not problem.settings.timelimit_is_default
+                    and problem.settings.timelimit != d.get('time_limit')
+                ):
+                    change = True
+                    d['time_limit'] = problem.settings.timelimit
+                break
+        if not found:
+            change = True
+            log(f'Add problem {problem.name}')
+            data.append(
+                {
+                    'id': problem.name,
+                    'label': problem.label,
+                    'name': problem.settings.name,
+                    'rgb': '#000000',
+                    'time_limit': problem.settings.timelimit,
+                }
+            )
+
+    if change:
+        if config.args.action in ['update_problems_yaml']:
+            a = 'y'
+        else:
+            log('Update problems.yaml with latest values? [Y/n]')
+            a = input().lower()
+        if a == '' or a[0] == 'y':
+            write_yaml(data, path)
+            log(f'Updated problems.yaml')
+    else:
+        if config.args.action == 'update_problems_yaml':
+            log(f'Already up to date')
 
 
 def export_problems(problems, cid):

--- a/bin/fuzz.py
+++ b/bin/fuzz.py
@@ -17,9 +17,7 @@ from util import *
 
 
 def _save_test(problem, command):
-    try:
-        import ruamel.yaml
-    except:
+    if not has_ryaml:
         error('Fuzzing needs the ruamel.yaml python3 library. Install python[3]-ruamel.yaml.')
         return
 
@@ -27,11 +25,7 @@ def _save_test(problem, command):
     if not generators_yaml.is_file():
         generators_yaml.write_text('')
 
-    # Round-trip parsing.
-    yaml = ruamel.yaml.YAML(typ='rt')
-    yaml.default_flow_style = False
-    yaml.indent(mapping=2, sequence=4, offset=2)
-    data = yaml.load(generators_yaml)
+    data = read_yaml(generators_yaml)
 
     if data is None:
         data = ruamel.yaml.comments.CommentedMap()
@@ -51,7 +45,7 @@ def _save_test(problem, command):
     data['data']['fuzz']['data'].append(item)
 
     # Overwrite generators.yaml.
-    yaml.dump(data, generators_yaml)
+    write_yaml(data, generators_yaml)
 
 
 def _try_generator_invocation(problem, t, submissions, i):
@@ -148,9 +142,7 @@ def _try_generator_invocation(problem, t, submissions, i):
 
 
 def fuzz(problem):
-    try:
-        import ruamel.yaml
-    except:
+    if not has_ryaml:
         error('Fuzzing needs the ruamel.yaml python3 library. Install python[3]-ruamel.yaml.')
         return
 

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -21,12 +21,8 @@ from problem import Problem
 def check_type(name, obj, types, path=None):
     if not isinstance(types, list):
         types = [types]
-    if obj is None:
-        if obj in types:
-            return
-    else:
-        if any(obj is None if t is None else isinstance(obj, t) for t in types):
-            return
+    if any(isinstance(obj, t) for t in types):
+        return
     named_types = " or ".join(str(t) if t is None else t.__name__ for t in types)
     if path:
         fatal(
@@ -273,19 +269,19 @@ class Config:
     # Used at each directory or testcase level.
 
     def parse_solution(p, x, path):
-        check_type('Solution', x, [None, str], path)
+        check_type('Solution', x, [type(None), str], path)
         if x is None:
             return None
         return SolutionInvocation(p, x)
 
     def parse_visualizer(p, x, path):
-        check_type('Visualizer', x, [None, str], path)
+        check_type('Visualizer', x, [type(None), str], path)
         if x is None:
             return None
         return VisualizerInvocation(p, x)
 
     def parse_random_salt(p, x, path):
-        check_type('Random_salt', x, [None, str], path)
+        check_type('Random_salt', x, [type(None), str], path)
         if x is None:
             return ''
         return x
@@ -365,7 +361,7 @@ class TestcaseRule(Rule):
             yaml = {'input': yaml}
         elif isinstance(yaml, dict):
             assert 'input' in yaml
-            check_type('Input', yaml['input'], [None, str])
+            check_type('Input', yaml['input'], [type(None), str])
         else:
             assert False
 
@@ -980,7 +976,7 @@ class GeneratorConfig:
         self.parse_yaml(yaml)
 
     def parse_yaml(self, yaml):
-        check_type('Root yaml', yaml, [dict, None])
+        check_type('Root yaml', yaml, [type(None), dict])
         if yaml is None:
             yaml = dict()
         yaml['type'] = 'directory'
@@ -999,7 +995,7 @@ class GeneratorConfig:
             if name == 'bad' and parent.path == Path('.') and listed is False:
                 return None
 
-            check_type('Testcase/directory', yaml, [None, str, dict], parent.path)
+            check_type('Testcase/directory', yaml, [type(None), str, dict], parent.path)
             if not is_testcase(yaml) and not is_directory(yaml):
                 fatal(
                     f'Could not parse {parent.path/name} as a testcase or directory. Try setting the type: key.'
@@ -1044,7 +1040,7 @@ class GeneratorConfig:
                 for id, dictionary in enumerate(yaml['data'], start=1):
                     check_type('Elements of data', dictionary, dict, d.path)
                     for key in dictionary:
-                        check_type('Testcase/directory name', key, [str, None], d.path)
+                        check_type('Testcase/directory name', key, [type(None), str], d.path)
 
                     for child_name, child_yaml in sorted(dictionary.items()):
                         if d.numbered:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1,21 +1,16 @@
 import hashlib
+import io
 import re
 import shutil
-import yaml as yamllib
-import queue
-import threading
-import signal
 
 from pathlib import Path, PurePosixPath
 
 import config
 import program
-import validate
 import run
 import parallel
 
 from util import *
-from problem import Problem
 
 
 def check_type(name, obj, types, path=None):
@@ -751,7 +746,7 @@ class TestcaseRule(Rule):
 
         # Update metadata
         if not skipped:
-            yamllib.dump(t.cache_data, meta_path.open('w'))
+            write_yaml(t.cache_data, meta_path)
 
         # If the .in was changed but not overwritten, check_deterministic will surely fail.
         if not skipped_in:
@@ -870,7 +865,9 @@ class Directory(Rule):
         testdata_yaml_path = dir_path / 'testdata.yaml'
         if d.testdata_yaml is not None:
             if d.testdata_yaml:
-                yaml_text = yamllib.dump(d.testdata_yaml)
+                buf = io.StringIO()
+                write_yaml(d.testdata_yaml, buf)
+                yaml_text = buf.getvalue()
                 if not testdata_yaml_path.is_file():
                     testdata_yaml_path.write_text(yaml_text)
                 else:

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -8,13 +8,6 @@ import sys
 
 from pathlib import Path
 
-try:
-    import ruamel.yaml
-
-    has_ryaml = True
-except:
-    has_ryaml = False
-
 import config
 import parallel
 import program

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -13,12 +13,16 @@ try:
     from questionary import Validator, ValidationError
 
     has_questionary = True
+
     class EmptyValidator(Validator):
         def validate(self, document):
             if len(document.text) == 0:
                 raise ValidationError(message="Please enter a value")
+
+
 except:
     has_questionary = False
+
 
 def _ask_variable(name, default=None, allow_empty=False):
     while True:
@@ -27,16 +31,20 @@ def _ask_variable(name, default=None, allow_empty=False):
         if val != '' or allow_empty:
             return val
 
+
 def _ask_variable_string(name, default=None, allow_empty=False):
     if has_questionary:
         try:
             validate = None if allow_empty else EmptyValidator
-            return questionary.text(name + ':', default=default or '', validate=validate).unsafe_ask()
+            return questionary.text(
+                name + ':', default=default or '', validate=validate
+            ).unsafe_ask()
         except KeyboardInterrupt:
             fatal('Running interrupted')
     else:
         text = f' ({default})' if default else ''
         return _ask_variable(name + text, default if default else '', allow_empty)
+
 
 def _ask_variable_bool(name, default=True):
     if has_questionary:
@@ -48,17 +56,21 @@ def _ask_variable_bool(name, default=True):
         text = ' (Y/n)' if default else ' (y/N)'
         return _ask_variable(name + text, 'Y' if default else 'N').lower()[0] == 'y'
 
+
 def _ask_variable_choice(name, choices, default=None):
     if has_questionary:
         try:
             plain = questionary.Style([('selected', 'noreverse')])
-            return questionary.select(name + ':', choices=choices, default=default, style=plain).unsafe_ask()
+            return questionary.select(
+                name + ':', choices=choices, default=default, style=plain
+            ).unsafe_ask()
         except KeyboardInterrupt:
             fatal('Running interrupted')
     else:
         default = default or choices[0]
         text = f' ({default})' if default else ''
         return _ask_variable(name + text, default if default else '')
+
 
 def _license_choices():
     return ['cc by-sa', 'cc by', 'cc0', 'public domain', 'educational', 'permission', 'unknown']
@@ -131,22 +143,20 @@ def new_problem():
         if config.args.problemname
         else _ask_variable_string('dirname', _alpha_num(problemname))
     )
-    author = (
-        config.args.author if config.args.author else _ask_variable_string('author')
-    )
+    author = config.args.author if config.args.author else _ask_variable_string('author')
 
     validator_flags = ''
     if config.args.validation:
         assert config.args.validation in ['default', 'custom', 'custom interactive']
         validation = config.args.validation
     else:
-        validation = _ask_variable_choice('validation', ['default','float','custom','custom interactive'])
+        validation = _ask_variable_choice(
+            'validation', ['default', 'float', 'custom', 'custom interactive']
+        )
         if validation == 'float':
             validation = 'default'
             validator_flags = 'validator_flags:\n  float_tolerance 1e-6\n'
             log(f'Using default float tolerance of 1e-6')
-
-
 
     # Read settings from the contest-level yaml file.
     variables = contest.contest_yaml()
@@ -160,10 +170,18 @@ def new_problem():
     }.items():
         variables[k] = v
 
-    variables['source'] = _ask_variable_string('source', variables.get('source', variables.get('name', '')), True)
-    variables['source_url'] = _ask_variable_string('source url', variables.get('source_url', ''), True)
-    variables['license'] = _ask_variable_choice('license', _license_choices(),  variables.get('license', None))
-    variables['rights_owner'] = _ask_variable_string('rights owner', variables.get('rights_owner', 'author'))
+    variables['source'] = _ask_variable_string(
+        'source', variables.get('source', variables.get('name', '')), True
+    )
+    variables['source_url'] = _ask_variable_string(
+        'source url', variables.get('source_url', ''), True
+    )
+    variables['license'] = _ask_variable_choice(
+        'license', _license_choices(), variables.get('license', None)
+    )
+    variables['rights_owner'] = _ask_variable_string(
+        'rights owner', variables.get('rights_owner', 'author')
+    )
 
     # Copy tree from the skel directory, next to the contest, if it is found.
     skeldir, preserve_symlinks = get_skel_dir(target_dir)

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -190,41 +190,26 @@ def new_problem():
     problems_yaml = target_dir / 'problems.yaml'
 
     if problems_yaml.is_file():
-        try:
-            import ruamel.yaml
-
-            ryaml = ruamel.yaml.YAML(typ='rt')
-            ryaml.default_flow_style = False
-            ryaml.indent(mapping=2, sequence=4, offset=2)
-            data = ryaml.load(problems_yaml) or []
+        if has_ryaml:
+            data = read_yaml(problems_yaml) or []
             prev_label = data[-1]['label'] if data else None
             next_label = (
                 ('X' if contest.contest_yaml().get('testsession') else 'A')
                 if prev_label is None
                 else prev_label[:-1] + chr(ord(prev_label[-1]) + 1)
             )
-            # Name and timelimits are overridden by problem.yaml, but still required.
+            # Name and time limits are overridden by problem.yaml, but still required.
             data.append(
                 {
                     'id': dirname,
-                    'name': problemname,
                     'label': next_label,
+                    'name': problemname,
                     'rgb': '#000000',
-                    'timelimit': 1.0,
+                    'time_limit': 1.0,
                 }
             )
-            ryaml.dump(
-                data,
-                problems_yaml,
-                # Remove spaces at the start of each (non-commented) line, caused by the indent configuration.
-                # If there was a top-level key (like `problems:`), this wouldn't be needed...
-                # See also: https://stackoverflow.com/a/58773229
-                transform=lambda yaml_str: "\n".join(
-                    line if line.strip().startswith('#') else line[2:]
-                    for line in yaml_str.split("\n")
-                ),
-            )
-        except NameError as e:
+            write_yaml(data, problems_yaml)
+        else:
             error('ruamel.yaml library not found. Please update problems.yaml manually.')
 
     copytree_and_substitute(

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -110,10 +110,11 @@ def get_problems():
         problems = []
         for p in problemlist:
             shortname = p['id']
-            if 'label' in p:
-                label = p['label']
+            if 'label' not in p:
+                fatal(f'Found no label for problem {shortname}.')
+            label = p['label']
             if label == '':
-                fatal(f'Found empty label for problem {shortname}')
+                fatal(f'Found empty label for problem {shortname}.')
             if label in labels:
                 fatal(f'label {label} found twice for problem {shortname} and {labels[label]}.')
             labels[label] = shortname

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -435,7 +435,11 @@ Run this from one of:
     )
     move_or_remove_group.add_argument('--move-to', help='Move failing testcases to this directory.')
 
-    validate_parser.add_argument('--skip-testcase-sanity-checks', action='store_true', help='Skip sanity checks on testcases.')
+    validate_parser.add_argument(
+        '--skip-testcase-sanity-checks',
+        action='store_true',
+        help='Skip sanity checks on testcases.',
+    )
 
     # constraints validation
     constraintsparser = subparsers.add_parser(
@@ -535,9 +539,8 @@ Run this from one of:
     genparser.add_argument(
         '--skip-testcase-sanity-checks',
         action='store_true',
-        help='Skip sanity checks on testcases.'
+        help='Skip sanity checks on testcases.',
     )
-
 
     # Fuzzer
     fuzzparser = subparsers.add_parser(
@@ -594,7 +597,7 @@ Run this from one of:
     runparser.add_argument(
         '--skip-testcase-sanity-checks',
         action='store_true',
-        help='Skip sanity checks on testcases.'
+        help='Skip sanity checks on testcases.',
     )
 
     # Test
@@ -642,7 +645,11 @@ Run this from one of:
         '--cleanup-generated', action='store_true', help='Clean up generated testcases afterwards.'
     )
     allparser.add_argument('--force', '-f', action='store_true', help='Delete all untracked files.')
-    allparser.add_argument('--skip-testcase-sanity-checks', action='store_true', help='Skip sanity checks on testcases.')
+    allparser.add_argument(
+        '--skip-testcase-sanity-checks',
+        action='store_true',
+        help='Skip sanity checks on testcases.',
+    )
 
     # Build DomJudge zip
     zipparser = subparsers.add_parser(

--- a/bin/util.py
+++ b/bin/util.py
@@ -483,12 +483,15 @@ def write_yaml(data, path):
         # This is only needed when the YAML data is a list of items, like in the problems.yaml file.
         # See also: https://stackoverflow.com/a/58773229
         transform=(
-            lambda yaml_str: "\n".join(
-                line if line.strip().startswith('#') else line[2:] for line in yaml_str.split("\n")
+            (
+                lambda yaml_str: "\n".join(
+                    line if line.strip().startswith('#') else line[2:]
+                    for line in yaml_str.split("\n")
+                )
             )
-        )
-        if isinstance(data, list)
-        else None,
+            if isinstance(data, list)
+            else None
+        ),
     )
 
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -568,7 +568,9 @@ def substitute_dir_variables(dirname, variables):
 
 # copies a directory recursively and substitutes {%key%} by their value in text files
 # reference: https://docs.python.org/3/library/shutil.html#copytree-example
-def copytree_and_substitute(src, dst, variables, exist_ok=True, *, preserve_symlinks=True, base=None):
+def copytree_and_substitute(
+    src, dst, variables, exist_ok=True, *, preserve_symlinks=True, base=None
+):
     if base is None:
         base = src
 
@@ -586,7 +588,12 @@ def copytree_and_substitute(src, dst, variables, exist_ok=True, *, preserve_syml
                 dstFile = dst / name
 
                 copytree_and_substitute(
-                    srcFile, dstFile, variables, exist_ok, preserve_symlinks=preserve_symlinks, base=base
+                    srcFile,
+                    dstFile,
+                    variables,
+                    exist_ok,
+                    preserve_symlinks=preserve_symlinks,
+                    base=base,
                 )
             except OSError as why:
                 errors.append((srcFile, dstFile, str(why)))


### PR DESCRIPTION
Now, all YAML files are read using `util.read_yaml` and written using `util.write_yaml`.
These function abstract over the indentation settings that used to be set all over the place.
`util.write_yaml` uses `ruamel.yaml`, so before using that function, you should check `util.has_ryaml`.