### PR TITLE
[util] Add threading lock to write_yaml

### DIFF
--- a/bin/util.py
+++ b/bin/util.py
@@ -474,8 +474,13 @@ def read_yaml_settings(path):
     return settings
 
 
+# Only allow one thread to write at the same time. Else, e.g., generating test cases in parallel goes wrong.
+write_yaml_lock = threading.Lock()
+
+
 # Writing a yaml file only works when ruamel.yaml is loaded. Check if `has_ryaml` is True before using.
 def write_yaml(data, path):
+    write_yaml_lock.acquire()
     ryaml.dump(
         data,
         path,
@@ -493,6 +498,7 @@ def write_yaml(data, path):
             else None
         ),
     )
+    write_yaml_lock.release()
 
 
 # glob, but without hidden files


### PR DESCRIPTION
I started getting flaky errors when running `bt generate` (which by default runs in parallel), like this one:

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/9739541/158450712-2b3e3c95-0991-486e-8331-852db802fc92.png)

</details>

Adding a threading lock seems to fix that :smile: 