### PR TITLE
Add `rename_problem` command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: trailing-whitespace
         exclude: ^test/
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black
         exclude: ^test/

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -19,7 +19,6 @@ try:
             if len(document.text) == 0:
                 raise ValidationError(message="Please enter a value")
 
-
 except:
     has_questionary = False
 
@@ -215,6 +214,35 @@ def new_problem():
     copytree_and_substitute(
         skeldir, target_dir / dirname, variables, exist_ok=True, preserve_symlinks=preserve_symlinks
     )
+
+
+def rename_problem(problem):
+    if not has_ryaml:
+        fatal('ruamel.yaml library not found.')
+
+    problemname = (
+        config.args.problemname if config.args.problemname else _ask_variable_string('problem name')
+    )
+    dirname = (
+        _alpha_num(problemname)
+        if config.args.problemname
+        else _ask_variable_string('dirname', _alpha_num(problemname))
+    )
+
+    shutil.move(problem.name, dirname)
+
+    problem_yaml = Path(dirname) / 'problem.yaml'
+    data = read_yaml(problem_yaml)
+    data['name'] = problemname
+    write_yaml(data, problem_yaml)
+
+    problems_yaml = Path('problems.yaml')
+    if problems_yaml.is_file():
+        data = read_yaml(problems_yaml) or []
+        prob = next(p for p in data if p['id'] == problem.name)
+        prob['id'] = dirname
+        prob['name'] = problemname
+        write_yaml(data, problems_yaml)
 
 
 def copy_skel_dir(problems):

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -239,10 +239,11 @@ def rename_problem(problem):
     problems_yaml = Path('problems.yaml')
     if problems_yaml.is_file():
         data = read_yaml(problems_yaml) or []
-        prob = next(p for p in data if p['id'] == problem.name)
-        prob['id'] = dirname
-        prob['name'] = problemname
-        write_yaml(data, problems_yaml)
+        prob = next((p for p in data if p['id'] == problem.name), None)
+        if prob is not None:
+            prob['id'] = dirname
+            prob['name'] = problemname
+            write_yaml(data, problems_yaml)
 
 
 def copy_skel_dir(problems):

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -370,6 +370,12 @@ Run this from one of:
     )
     skelparser.add_argument('--skel', help='Skeleton problem directory to copy from.')
 
+    # Rename problem
+    renameproblemparser = subparsers.add_parser(
+        'rename_problem', parents=[global_parser], help='Rename a problem, including its directory.'
+    )
+    renameproblemparser.add_argument('problemname', nargs='?', help='The new name of the problem,')
+
     # Problem statements
     pdfparser = subparsers.add_parser(
         'pdf', parents=[global_parser], help='Build the problem statement pdf.'
@@ -741,11 +747,11 @@ def run_parsed_arguments(args):
             config.args.testcases = []
 
     # Skel commands.
-    if action in ['new_contest']:
+    if action == 'new_contest':
         skel.new_contest()
         return
 
-    if action in ['new_problem']:
+    if action == 'new_problem':
         skel.new_problem()
         return
 
@@ -788,7 +794,7 @@ def run_parsed_arguments(args):
 
         return
 
-    if action in ['stats']:
+    if action == 'stats':
         stats.stats(problems)
         return
 
@@ -796,8 +802,14 @@ def run_parsed_arguments(args):
         print_sorted(problems)
         return
 
-    if action in ['samplezip']:
+    if action == 'samplezip':
         export.build_samples_zip(problems)
+        return
+
+    if action == 'rename_problem':
+        if level == 'problemset':
+            fatal('rename_problem only works for a problem')
+        skel.rename_problem(problems[0])
         return
 
     if action == 'gitlabci':

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -28,6 +28,7 @@ This lists all subcommands and their most important options.
   - [`bt new_contest [contestname]`](#new_contest)
   - [`bt new_problem [problemname] [--author AUTHOR] [--validation {default,custom,custom interactive}] [--skel SKEL]`](#new_problem)
   - [`bt skel [--skel SKEL] directory [directory ...]`](#skel)
+  - [`bt rename_problem [problemname]`](#rename_problem)
   - [`bt gitlabci`](#gitlabci)
 - Exporting
   - [`bt samplezip`](#samplezip)
@@ -367,6 +368,14 @@ Files are usually copied from [skel/problem](../skel/problem), but this can be o
 
 Copy the given directory from [../skel/problem](../skel/problem) to the current problem directory. Directories passed must be relative to the problem root, e.g. `generators` or `output_validators/output_validator`.
 The skel directory is found as with the `new_problem` command and can be overridden using `--skel`.
+
+## `rename_problem`
+
+Rename a problem, including its problem directory. If `problems.yaml` is present, also rename the problem in this file. Do not forget to pass a `--problem` to rename when running this from a contest directory.
+
+**Flags**
+
+- `[<problem name>]`: The new name of the problem. Will be asked interactively if not specified.
 
 ## `gitlabci`
 


### PR DESCRIPTION
This made my life a bit easier today :innocent: 

I tested running it from both a contest directory and a problem directory. Both work fine, although my shell prompt did not immediately pick up the rename when running the command from a problem directory :stuck_out_tongue: 

I've added the command to the documentation, should there also be tests for this?