### PR TITLE
[export] Add `--colors` parameter to `update_problems_yaml` command

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -74,7 +74,7 @@ grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_
 grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
 # fmt: off
-args_list = ['1', 'add_manual', 'all', 'api', 'author', 'check_deterministic', 'clean', 'clean_generated', 'cleanup_generated', 'contest', 'contest_id', 'contestname', 'cp', 'cpp_flags', 'default_solution', 'directory', 'error', 'force', 'force_build', 'ignore_validators', 'input', 'interaction', 'interactive', 'kattis', 'memory', 'move_manual', 'move_to', 'no_bar', 'no_generate', 'no_solutions', 'no_timelimit', 'order', 'order_from_ccs', 'output', 'password', 'problem', 'problemname', 'remove', 'samples', 'scoreboard_repo', 'skel', 'skip', 'skip_solution', 'skip_testcase_sanity_checks', 'skip_visualizer', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'username', 'validation', 'watch', 'web']
+args_list = ['1', 'add_manual', 'all', 'api', 'author', 'check_deterministic', 'clean', 'clean_generated', 'cleanup_generated', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'cpp_flags', 'default_solution', 'directory', 'error', 'force', 'force_build', 'ignore_validators', 'input', 'interaction', 'interactive', 'kattis', 'memory', 'move_manual', 'move_to', 'no_bar', 'no_generate', 'no_solutions', 'no_timelimit', 'order', 'order_from_ccs', 'output', 'password', 'problem', 'problemname', 'remove', 'samples', 'scoreboard_repo', 'skel', 'skip', 'skip_solution', 'skip_testcase_sanity_checks', 'skip_visualizer', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'username', 'validation', 'watch', 'web']
 # fmt: on
 
 
@@ -103,6 +103,7 @@ TEST_TLE_SUBMISSIONS = False
 # The default timeout used for generators, visualizer etc.
 DEFAULT_TIMEOUT = 30
 DEFAULT_INTERACTION_TIMEOUT = 60
+
 
 def get_timeout():
     return args.timeout or DEFAULT_TIMEOUT

--- a/bin/export.py
+++ b/bin/export.py
@@ -285,7 +285,7 @@ def update_problems_yaml(problems, colors=None):
 
     log('Updating problems.yaml')
     path = Path('problems.yaml')
-    data = read_yaml(path) if path.is_file() else []
+    data = path.is_file() and read_yaml(path) or []
 
     change = False
     for problem in problems:

--- a/bin/export.py
+++ b/bin/export.py
@@ -275,7 +275,7 @@ def export_contest():
     return new_cid
 
 
-def update_problems_yaml(problems):
+def update_problems_yaml(problems, colors=None):
     # Update name and timelimit values.
     if not has_ryaml:
         log(
@@ -320,6 +320,17 @@ def update_problems_yaml(problems):
                     'time_limit': problem.settings.timelimit,
                 }
             )
+
+    if colors:
+        if len(data) != len(colors):
+            warn(
+                f'Number of colors ({len(colors)}) is not equal to the number of problems ({len(data)})'
+            )
+        for d, c in zip(data, colors):
+            color = ('' if c.startswith('#') else '#') + c
+            if 'rgb' not in d or d['rgb'] != color:
+                change = True
+            d['rgb'] = color
 
     if change:
         if config.args.action in ['update_problems_yaml']:

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -698,6 +698,10 @@ Run this from one of:
         parents=[global_parser],
         help='Update the problems.yaml with current names and timelimits.',
     )
+    updateproblemsyamlparser.add_argument(
+        '--colors',
+        help='Set the colors of the problems. Comma-separated list of hex-codes.',
+    )
 
     # Print the corresponding temporary directory.
     tmpparser = subparsers.add_parser(
@@ -966,7 +970,9 @@ def run_parsed_arguments(args):
         if action in ['export']:
             export.export_contest_and_problems(problems)
         if action in ['update_problems_yaml']:
-            export.update_problems_yaml(problems)
+            export.update_problems_yaml(
+                problems, config.args.colors.split(",") if config.args.colors else None
+            )
 
     if not success or config.n_error > 0 or config.n_warn > 0:
         sys.exit(1)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -36,6 +36,7 @@ This lists all subcommands and their most important options.
 - Misc
   - [`bt all [-v] [--cp] [--no-timelimit] [--cleanup-generated]`](#all)
   - [`bt sort`](#sort)
+  - [`bt update_problems_yaml [--colors COLORS]`](#update_problems_yaml)
   - [`bt tmp [--clean]`](#tmp)
   - `bt create_slack_channels --token xoxb-...`
 
@@ -532,6 +533,16 @@ A : appealtotheaudience
 B : breakingbranches
 ...
 ```
+
+## `update_problems_yaml`
+
+`bt update_problems_yaml` updates the `problems.yaml` file of the contest.
+This file should contain a list of problems, with for every problem the keys `id`, `label`, `name`, `rgb`, and `time_limit`.
+
+**Flags**
+
+- `--colors`: Apply the given list of colors to the list of problems, in the same order as in `problems.yaml`.
+  Should be a comma-separated list of colors (hash-sign is optional), e.g.: `--colors ff0000,00ff00,0000ff`.
 
 ## `tmp`
 


### PR DESCRIPTION
This PR adds a `--colors` parameter to the `update_problems_yaml` command, which can be used to set a list of hex colours from the command line. Typically, when I get a list of balloon colours from an organisation, it's easier to transform this into a comma-separated list than to manually copy all the hex codes :stuck_out_tongue: 

I've also added the command (including this new parameter) to the [documentation](doc/commands.md) :smile:

P.S. I would've preferred to use the British "colours" instead of "colors", but it looks like most of BAPCtools uses American English (which is consistent with most programming tools, so I guess it's fine :upside_down_face: )