### PR TITLE
[export] Export single problem, check if user has a team, and documentation updates

### DIFF
--- a/bin/tools.py
+++ b/bin/tools.py
@@ -942,6 +942,9 @@ def run_parsed_arguments(args):
         if len(problems) > 1:
             print(file=sys.stderr)
 
+    if action in ['export']:
+        export.export_contest_and_problems(problems)
+
     if level == 'problemset':
         print(f'{Style.BRIGHT}CONTEST {contest}{Style.RESET_ALL}', file=sys.stderr)
 
@@ -968,8 +971,6 @@ def run_parsed_arguments(args):
             if config.args.kattis:
                 outfile = contest + '-kattis.zip'
             export.build_contest_zip(problems, problem_zips, outfile, config.args)
-        if action in ['export']:
-            export.export_contest_and_problems(problems)
         if action in ['update_problems_yaml']:
             export.update_problems_yaml(
                 problems, config.args.colors.split(",") if config.args.colors else None

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -33,6 +33,7 @@ This lists all subcommands and their most important options.
 - Exporting
   - [`bt samplezip`](#samplezip)
   - [`bt zip [--skip] [--force] [--kattis] [--no-solutions]`](#zip)
+  - [`bt export`](#export)
 - Misc
   - [`bt all [-v] [--cp] [--no-timelimit] [--cleanup-generated]`](#all)
   - [`bt solve_stats [--contest-id CONTESTID] [--post-freeze]`](#solve_stats)
@@ -508,6 +509,13 @@ When run for a contest:
   - The contest level zip is written to `contest/<contest>-kattis.zip`
   - Kattis needs the `input_validators` directory, while DOMjudge doesn't use this.
   - Kattis problem zips get an additional top level directory named after the problem shortname.
+
+## `export`
+
+This command uploads the `contest.yaml`, `problems.yaml`, and problem zips to DOMjudge.
+Make sure to run the [`bt zip`](#zip) command before exporting, this does not happen automatically.
+
+When run for a single problem, `contest.yaml` and `problems.yaml` are uploaded for the entire contest, but only the zip for the selected problem is uploaded.
 
 # Misc
 


### PR DESCRIPTION
### Support (re-)exporting a single problem
This is useful when a contest is already imported, but you change the time limit or some test cases for a single problem afterwards.<br>
Note that this probably doesn't work on DOMjudge 8.1.3 and older.
These older DOMjudge versions require `delete_old_date: True` to work properly
(see DOMjudge/domjudge@cb68f9b).

### Add documentation to doc/commands.md
Speaks for itself :slightly_smiling_face: 

### Check if exporting user is associated to a team
I made the check in such a way that it works for the different "Data source" configurations in DOMjudge (i.e., this code should work both when using internal (numeric) IDs and when using external IDs).

### Remove TODO about reusing problem IDs because it's not possible
Same deal about the "Data source" configuration holds here:
we could probably get away with reusing the result of `export_problems` if DOMjudge would always use external IDs.
However, with numeric IDs, they cannot be matched directly with the problems that we are exporting.