### PR TITLE
Improve startup time

### DIFF
--- a/bin/contest.py
+++ b/bin/contest.py
@@ -1,12 +1,7 @@
 from pathlib import Path
-from util import *
 import json
 
-# Optional, only needed for API stuff
-try:
-    import requests
-except:
-    pass
+from util import *
 
 # Read the contest.yaml, if available
 _contest_yaml = None
@@ -86,6 +81,8 @@ def get_contests():
 
 
 def call_api(method, endpoint, **kwargs):
+    import requests  # Slow import, so only import it inside this function.
+
     url = get_api() + endpoint
     verbose(f'{method} {url}')
     r = requests.request(

--- a/bin/slack.py
+++ b/bin/slack.py
@@ -1,9 +1,5 @@
-try:
-    import requests
-except:
-    pass
-
 from util import *
+
 
 # Function to create a slack channel for each problem
 def create_slack_channels(problems):
@@ -14,13 +10,7 @@ def create_slack_channels(problems):
 # The slack user token is of the form xoxp-...
 def create_slack_channel(name):
     verbose(f'Creating channel {name}')
-    r = requests.post(
-        'https://slack.com/api/conversations.create',
-        {
-            'token': config.args.token,
-            'name': name,
-        },
-    )
+    r = call_slack_api('conversations.create', name=name)
     if not r.ok:
         error(r.text)
         return
@@ -33,12 +23,7 @@ def create_slack_channel(name):
 
 def join_slack_channels(problems):
     verbose('Reading conversations list')
-    r = requests.post(
-        'https://slack.com/api/conversations.list',
-        {
-            'token': config.args.token,
-        },
-    ).json()
+    r = call_slack_api('conversations.list').json()
     if not r['ok']:
         error(r['error'])
         return
@@ -53,13 +38,7 @@ def join_slack_channels(problems):
 
 def join_slack_channel(name, id):
     verbose(f'joining channel {name} id {id}')
-    r = requests.post(
-        'https://slack.com/api/conversations.join',
-        {
-            'token': config.args.token,
-            'channel': id,
-        },
-    )
+    r = call_slack_api('conversations.join', channel=id)
     if not r.ok:
         error(r.text)
         return
@@ -68,3 +47,12 @@ def join_slack_channel(name, id):
         error(response['error'])
         return
     log(f'Created and joined channel {name}')
+
+
+def call_slack_api(path, **kwargs):
+    import requests  # Slow import, so only import it inside this function.
+
+    return requests.post(
+        f'https://slack.com/api/{path}',
+        {'token': config.args.token, **kwargs},
+    )

--- a/bin/solve_stats.py
+++ b/bin/solve_stats.py
@@ -1,23 +1,13 @@
 from os import makedirs
 from pathlib import Path
 
-try:
-    import matplotlib.pyplot as plt
-
-    has_matplotlib = True
-except:
-    has_matplotlib = False
-
 from contest import call_api, get_contest_id
-from util import error, ProgressBar
+from util import ProgressBar
 
 
 def generate_solve_stats(post_freeze):
-    if not has_matplotlib:
-        error(
-            'Generating solve stats needs the matplotlib python3 library. Install python[3]-matplotlib.'
-        )
-        return
+    # Import takes more than 1000 ms to evaluate, so only import inside function (when it is actually needed)
+    import matplotlib.pyplot as plt
 
     contest_id = get_contest_id()
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -185,7 +185,6 @@ def get_problems():
             # Sort by increasing difficulty, extracted from the CCS api.
             # Get active contest.
 
-            api = get_api()
             cid = get_contest_id()
             solves = dict()
 

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,8 @@ Optional dependencies, required for some subcommands:
   These are only needed for building `pdf` files, not for `run` and `validate` and such.
 - The [matplotlib library](https://pypi.org/project/matplotlib/) via `pip install matplotlib` or the `python[3]-matplotlib` Linux package.
   - This is optional and only used by the `solve_stats` command.
+- The [requests library](https://pypi.org/project/requests/) via `pip install requests` or the `python[3]-requests` Linux package.
+  - This is optional and only used by the commands that call the DOMjudge API (`export`, `solutions --order-from-css`, and `solve_stats`) or the Slack API (`create_slack_channels` command).
 - The [questionary library](https://pypi.org/project/questionary/) via `pip install questionary`.
   - This is optional and only used by the `new_contest` and `new_problem` commands.
 


### PR DESCRIPTION
I noticed that tab-completion was slower than it used to be. After some investigation, it turns out that I caused this myself :innocent: 

Turns out that importing Matplotlib takes more than a second to resolve. So, instead of doing a conditional import at the top of the file, I've moved the import inside the function, so that it's only imported when it's actually used:

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/9739541/224509716-6382ac14-357c-4c08-b1eb-aa4c5892ac40.png) | ![image](https://user-images.githubusercontent.com/9739541/224509781-2b0785da-88e4-489a-871a-fac1aa20861b.png) |

And while I was at it, I found that the Requests library also takes significantly longer to resolve than most other packages, so I did the same there:

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/9739541/224509921-76de00fb-50dd-41a3-bbc1-edfa1f5c8193.png) | ![image](https://user-images.githubusercontent.com/9739541/224509925-e11dcb31-03fd-4347-b266-3e20ddf92fe9.png) |

P.S. @RagnarGrootKoerkamp Can you also add the `python-requests` dependency to https://github.com/RagnarGrootKoerkamp/bapctools-git/? :slightly_smiling_face: 