### PR TITLE
[latex] Small fixes

### DIFF
--- a/bin/latex.py
+++ b/bin/latex.py
@@ -55,7 +55,7 @@ def create_samples_file(problem):
                 interaction_file.write_text(cur)
 
                 mode = 'InteractiveRead' if last == '<' else 'InteractiveWrite'
-                samples_data += f'\\{mode}{{{interaction_file}}}\n'
+                samples_data += f'\\{mode}{{{interaction_file.as_posix()}}}\n'
                 interaction_id += 1
 
             for line in lines.splitlines():
@@ -71,7 +71,9 @@ def create_samples_file(problem):
             # Already handled above.
             if sample.in_path.with_suffix('.interaction').is_file():
                 continue
-            samples_data += f'\\Sample{{{sample.in_path}}}{{{sample.ans_path}}}\n'
+            samples_data += (
+                f'\\Sample{{{sample.in_path.as_posix()}}}{{{sample.ans_path.as_posix()}}}\n'
+            )
     samples_file_path.write_text(samples_data)
 
 
@@ -173,9 +175,7 @@ def build_problem_pdf(problem, solutions=False):
 
     local_data = Path(main_file)
     util.copy_and_substitute(
-        local_data
-        if local_data.is_file()
-        else config.tools_root / 'latex' / main_file,
+        local_data if local_data.is_file() else config.tools_root / 'latex' / main_file,
         builddir / main_file,
         {
             'problemlabel': problem.label,

--- a/latex/contest-problem.tex
+++ b/latex/contest-problem.tex
@@ -1,12 +1,12 @@
 \begingroup\graphicspath{{{%problemdir%}/problem_statement/}}
-	\renewcommand{\problemlabel}{{%problemlabel%}}
-	\renewcommand{\problemyamlname}{{%problemyamlname%}}
-	\renewcommand{\problemauthor}{{%problemauthor%}}
-	\renewcommand{\timelimit}{{%timelimit%}}
-	\input{{%problemdir%}/problem_statement/problem.en.tex}
-	\input{{%builddir%}/samples.tex}
-	\renewcommand{\problemlabel}{}
-	\renewcommand{\problemyamlname}{}
-	\renewcommand{\problemauthor}{}
-	\renewcommand{\timelimit}{}
+    \renewcommand{\problemlabel}{{%problemlabel%}}
+    \renewcommand{\problemyamlname}{{%problemyamlname%}}
+    \renewcommand{\problemauthor}{{%problemauthor%}}
+    \renewcommand{\timelimit}{{%timelimit%}}
+    \input{{%problemdir%}/problem_statement/problem.en.tex}
+    \input{{%builddir%}/samples.tex}
+    \renewcommand{\problemlabel}{}
+    \renewcommand{\problemyamlname}{}
+    \renewcommand{\problemauthor}{}
+    \renewcommand{\timelimit}{}
 \endgroup

--- a/latex/contest-solution.tex
+++ b/latex/contest-solution.tex
@@ -1,8 +1,8 @@
 \begingroup\graphicspath{{{%problemdir%}/problem_statement/}}
-	\renewcommand{\problemlabel}{{%problemlabel%}}
-	\renewcommand{\problemyamlname}{{%problemyamlname%}}
-	\renewcommand{\problemauthor}{{%problemauthor%}}
-	\renewcommand{\timelimit}{{%timelimit%}}
-	\input{{%problemdir%}/problem_statement/solution.tex}
-	\renewcommand{\problemlabel}{}
+    \renewcommand{\problemlabel}{{%problemlabel%}}
+    \renewcommand{\problemyamlname}{{%problemyamlname%}}
+    \renewcommand{\problemauthor}{{%problemauthor%}}
+    \renewcommand{\timelimit}{{%timelimit%}}
+    \input{{%problemdir%}/problem_statement/solution.tex}
+    \renewcommand{\problemlabel}{}
 \endgroup

--- a/latex/contest-web.tex
+++ b/latex/contest-web.tex
@@ -28,15 +28,15 @@
 \begin{center}
     {\fontsize{12mm}{12mm}\selectfont \@title \par}
 
-	\vspace{2.8mm}
-	{\LARGE\fontfamily{ppl}\selectfont\emph{\@subtitle}}
+    \vspace{2.8mm}
+    {\LARGE\fontfamily{ppl}\selectfont\emph{\@subtitle}}
 
-	\vfill
-	\vfill
-	\includegraphics[height=5cm]{\logofile}
-	\vfill
+    \vfill
+    \vfill
+    \includegraphics[height=5cm]{\logofile}
+    \vfill
 
-	\listofproblems
+    \listofproblems
 \end{center}
 
 % 2ND PAGE WITH CC-BY-SA LICENCE
@@ -65,9 +65,9 @@ Creative Commons Attribution-ShareAlike 4.0 International License.
 
 % An empty page at the end for non-testsession.
 \if\@testsession0
-	\clearpage
-	\pagestyle{empty}
-	\mbox{}
+    \clearpage
+    \pagestyle{empty}
+    \mbox{}
 \fi
 
 \end{document}

--- a/latex/contest.tex
+++ b/latex/contest.tex
@@ -28,15 +28,15 @@
 \begin{center}
     {\fontsize{12mm}{12mm}\selectfont \@title \par}
 
-	\vspace{2.8mm}
-	{\LARGE\fontfamily{ppl}\selectfont\emph{\@subtitle}}
+    \vspace{2.8mm}
+    {\LARGE\fontfamily{ppl}\selectfont\emph{\@subtitle}}
 
-	\vfill
-	\vfill
-	\includegraphics[height=5cm]{\logofile}
-	\vfill
+    \vfill
+    \vfill
+    \includegraphics[height=5cm]{\logofile}
+    \vfill
 
-	\listofproblems
+    \listofproblems
 \end{center}
 
 % 2ND PAGE WITH CC-BY-SA LICENCE
@@ -65,9 +65,9 @@ Creative Commons Attribution-ShareAlike 4.0 International License.
 
 % An empty page at the end for non-testsession.
 \if\@testsession0
-	\clearpage
-	\pagestyle{empty}
-	\mbox{}
+    \clearpage
+    \pagestyle{empty}
+    \mbox{}
 \fi
 
 \end{document}

--- a/latex/images/blank-page-fr.tex
+++ b/latex/images/blank-page-fr.tex
@@ -1,5 +1,5 @@
 \documentclass[border=5pt]{standalone}
 \usepackage{frcursive}
 \begin{document}
-	\huge\cursive\emph{Ceci n'est pas une page blanche.}
+    \huge\cursive\emph{Ceci n'est pas une page blanche.}
 \end{document}

--- a/latex/problem.tex
+++ b/latex/problem.tex
@@ -1,11 +1,11 @@
 \documentclass{bapc}
 \begin{document}
 \begingroup\graphicspath{{{%problemdir%}/problem_statement/}}
-	\renewcommand{\problemlabel}{{%problemlabel%}}
-	\renewcommand{\problemyamlname}{{%problemyamlname%}}
-	\renewcommand{\problemauthor}{{%problemauthor%}}
-	\renewcommand{\timelimit}{{%timelimit%}}
-	\input{{%problemdir%}/problem_statement/problem.en.tex}
-	\input{{%builddir%}/samples.tex}
+    \renewcommand{\problemlabel}{{%problemlabel%}}
+    \renewcommand{\problemyamlname}{{%problemyamlname%}}
+    \renewcommand{\problemauthor}{{%problemauthor%}}
+    \renewcommand{\timelimit}{{%timelimit%}}
+    \input{{%problemdir%}/problem_statement/problem.en.tex}
+    \input{{%builddir%}/samples.tex}
 \endgroup
 \end{document}

--- a/latex/solution.tex
+++ b/latex/solution.tex
@@ -2,11 +2,11 @@
 \input{solutions-base.tex}
 \begin{document}
 \begingroup\graphicspath{{{%problemdir%}/problem_statement/}}
-	\renewcommand{\problemlabel}{{%problemlabel%}}
-	\renewcommand{\problemyamlname}{{%problemyamlname%}}
-	\renewcommand{\problemauthor}{{%problemauthor%}}
-	\renewcommand{\timelimit}{{%timelimit%}}
-	\input{{%problemdir%}/problem_statement/solution.tex}
-	\renewcommand{\problemlabel}{}
+    \renewcommand{\problemlabel}{{%problemlabel%}}
+    \renewcommand{\problemyamlname}{{%problemyamlname%}}
+    \renewcommand{\problemauthor}{{%problemauthor%}}
+    \renewcommand{\timelimit}{{%timelimit%}}
+    \input{{%problemdir%}/problem_statement/solution.tex}
+    \renewcommand{\problemlabel}{}
 \endgroup
 \end{document}

--- a/latex/solutions-base.tex
+++ b/latex/solutions-base.tex
@@ -63,7 +63,7 @@
 \newcommand{\printsolvestats}[3]{%
 	\vfill%
     \onslide<+->%
-	Statistics: #1 submissions, #2 accepted\ifnum#3=0\else, #3 unknown\fi%
+	Statistics: #1 submissions, #2 accepted\ifthenelse{\equal{#3}0}{}{, #3 unknown}%
 }
 
 % Define \solvestats for the current problem if the file exists.

--- a/latex/solutions-base.tex
+++ b/latex/solutions-base.tex
@@ -31,14 +31,14 @@
 \usepackage{wrapfig}
 
 \lstset{
-	backgroundcolor=\color{white},
-	tabsize=4,
-	language=python,
-	basicstyle=\footnotesize\ttfamily,
-	breaklines=true,
-	keywordstyle=\color[rgb]{0, 0, 1},
-	commentstyle=\color[rgb]{0, 0.5, 0},
-	stringstyle=\color{red}
+    backgroundcolor=\color{white},
+    tabsize=4,
+    language=python,
+    basicstyle=\footnotesize\ttfamily,
+    breaklines=true,
+    keywordstyle=\color[rgb]{0, 0, 1},
+    commentstyle=\color[rgb]{0, 0.5, 0},
+    stringstyle=\color{red}
 }
 
 \newcommand{\timelimit}{0.0s}
@@ -51,28 +51,28 @@
 
 % If solve_stats/activity/A.pdf exists, define the \activitychart command
 \IfFileExists{solve_stats/activity/A.pdf}{
-	\newcommand{\activitychart}{
-	  \ifdefempty{\problemlabel}{}{%
+    \newcommand{\activitychart}{
+      \ifdefempty{\problemlabel}{}{%
         \includegraphics[width=\textwidth,height=0.1\textheight]{solve_stats/activity/\problemlabel}%
-	  }%
-	}
+      }%
+    }
 }{
-	\newcommand{\activitychart}{}
+    \newcommand{\activitychart}{}
 }
 
 \newcommand{\printsolvestats}[3]{%
-	\vfill%
+    \vfill%
     \onslide<+->%
-	Statistics: #1 submissions, #2 accepted\ifthenelse{\equal{#3}0}{}{, #3 unknown}%
+    Statistics: #1 submissions, #2 accepted\ifthenelse{\equal{#3}0}{}{, #3 unknown}%
 }
 
 % Define \solvestats for the current problem if the file exists.
 \IfFileExists{problem_stats.tex}{
-	\newcommand{\solvestats}{\csname solvestats\problemlabel \endcsname}
-	\input{problem_stats.tex}
+    \newcommand{\solvestats}{\csname solvestats\problemlabel \endcsname}
+    \input{problem_stats.tex}
 }{
-	% If the file does not exist, use a placeholder.
-	\newcommand{\solvestats}{\printsolvestats{\ldots}{\ldots}{\ldots}}
+    % If the file does not exist, use a placeholder.
+    \newcommand{\solvestats}{\printsolvestats{\ldots}{\ldots}{\ldots}}
 }
 
 \usetheme[numbering=none,block=fill]{metropolis}
@@ -89,15 +89,15 @@
     \rule{0ex}{5.5ex}%
     \end{minipage}
     \begin{minipage}{0.4\paperwidth}%
-	\ifdefempty{\problemlabel}{%
-		\insertframetitle\strut%
-	}{%
-		\problemtitle%
-		\\[0.3em]%
-		\tiny%
-		Problem Author: \problemauthor%
+    \ifdefempty{\problemlabel}{%
+        \insertframetitle\strut%
+    }{%
+        \problemtitle%
+        \\[0.3em]%
+        \tiny%
+        Problem Author: \problemauthor%
         \strut%
-	}%
+    }%
     \end{minipage}%
     \hfill%
     \begin{minipage}{0.5\paperwidth}%

--- a/scripts/header.tex
+++ b/scripts/header.tex
@@ -1,7 +1,7 @@
 \newcommand{\problemname}[1]{}
 \newenvironment{Input}{
-	\subsection*{Input}
+    \subsection*{Input}
 }{}
 \newenvironment{Output}{
-	\subsection*{Output}
+    \subsection*{Output}
 }{}

--- a/test/problems/identity/problem_statement/problem.en.tex
+++ b/test/problems/identity/problem_statement/problem.en.tex
@@ -5,12 +5,12 @@
 Given $n$, print $n$.
 
 \begin{Input}
-	The input consists of:
-	\begin{itemize}
-		\item One line containing a single integer $0\leq n\leq \maxn$.
-	\end{itemize}
+    The input consists of:
+    \begin{itemize}
+        \item One line containing a single integer $0\leq n\leq \maxn$.
+    \end{itemize}
 \end{Input}
 
 \begin{Output}
-	Output a single line containing $n$.
+    Output a single line containing $n$.
 \end{Output}

--- a/test/problems/identity/problem_statement/solution.tex
+++ b/test/problems/identity/problem_statement/solution.tex
@@ -1,7 +1,7 @@
 \begin{frame}
-	\frametitle{\problemtitle}
+    \frametitle{\problemtitle}
     \begin{itemize}
-		\item Print $4$.
-		\solvestats
+        \item Print $4$.
+        \solvestats
     \end{itemize}
 \end{frame}

--- a/test/problems/solution_footer.tex
+++ b/test/problems/solution_footer.tex
@@ -1,4 +1,4 @@
 \begin{frame}
-	\frametitle{Stats}
-	\includegraphics[width=\textwidth]{solve_stats/language_stats}%
+    \frametitle{Stats}
+    \includegraphics[width=\textwidth]{solve_stats/language_stats}%
 \end{frame}


### PR DESCRIPTION
- Print paths to samples with .as_posix()
  
  This fixes a LaTeX compile error on Windows. Because Windows uses backslash as path separator, LaTeX thought that these paths were commands. As a fix, we can force the paths to print as_posix() (i.e., with forward slashes), because Windows also accepts this.

  Thanks to @alexbolfa for reporting this bug and testing this patch on their Windows machine :smile: 

- [latex] Fix compile error when using `\solvestats` without `solve_stats` directory
  
  Some silly mistake that I introduced, and encountered when working on the FPC :joy: 

- [latex] Consistently use spaces instead of tabs in *.tex files

  Speaks for itself :slightly_smiling_face: 