### PR TITLE
[interactive] Call `Popen` with `subprocess.PIPE`s instead of manual pipes from `os.pipe2`

### DIFF
--- a/bin/interactive.py
+++ b/bin/interactive.py
@@ -149,6 +149,15 @@ def run_interactive_testcase(
     # - Close remaining program + write end of pipe
     # - Close remaining read end of pipes
 
+    def set_pipe_size(pipe):
+        # Somehow, setting the pipe buffer size is necessary to avoid hanging in larger interactions.
+        # Note that this is equivalent to Popen's `pipesize` argument in Python 3.10,
+        # but we backported this for compatibility with older Python versions:
+        # https://github.com/python/cpython/pull/21921/files#diff-619941af4b328b6abf2dc02c54e774fc17acc1ac4172c14db27d6097cbbff92aR1590
+        # See also: https://github.com/RagnarGrootKoerkamp/BAPCtools/pull/251#issuecomment-1609353538
+        # Note: 1031 = fcntl.F_SETPIPE_SZ, but that constant is also only available in Python 3.10.
+        fcntl.fcntl(pipe, 1031, BUFFER_SIZE)
+
     interaction_file = None
     # TODO: Print interaction when needed.
     if interaction:
@@ -185,6 +194,11 @@ while True:
     # then we can wait for all program ins the same group
     gid = validator_pid
 
+    set_pipe_size(validator.stdin)
+    set_pipe_size(validator.stdout)
+    if validator_error is False:
+        set_pipe_size(validator.stderr)
+
     if interaction:
         team_tee = subprocess.Popen(
             ['python3', '-c', TEE_CODE, '>'],
@@ -203,6 +217,9 @@ while True:
         )
         val_tee_pid = val_tee.pid
 
+        set_pipe_size(team_tee.stdin)
+        set_pipe_size(val_tee.stdout)
+
     submission = subprocess.Popen(
         submission_command,
         stdin=(val_tee if interaction else validator).stdout,
@@ -213,7 +230,11 @@ while True:
     )
     submission_pid = submission.pid
 
+    if team_error is False:
+        set_pipe_size(submission.stderr)
+
     stop_kill_handler = threading.Event()
+
     def kill_handler_function():
         if stop_kill_handler.wait(timeout + 1):
             return


### PR DESCRIPTION
This fixes the problem that we had with Lowest Latency in BAPC 2022:

- Validation is set to `custom interactive` because the input is uniformly randomly generated for every run
- The interactor sends the input to the submission and closes `stdout`
- If the team submission reads until the end of `stdin`, it waits forever, because somehow, the submission process never gets to know that the input has ended

This was also a bug in DOMjudge back then, which was fixed in https://github.com/DOMjudge/domjudge/pull/1709, but I wanted to have this fixed in BAPCtools as well :slightly_smiling_face: 

The problem was that you can't really inspect the pipes that come from `os.pipe2` to see whether they are closed or not. Furthermore, `os.wait3` never reports any process terminating. I am guessing that, after the output validator closes stdout, it is not actually terminated by the OS, although I have no clue why.

After a few hours of debugging, I found that starting the validator with `stdout=subprocess.PIPE` _does_ allow the output validator to close `stdout` and correctly terminate. Based on this, I've moved the creation of the `tee` processes _after_ the creation of the validator process, which is slightly ugly, but this is the only way to tie all the pipes together while allowing the output validator to correctly terminate. :upside_down_face: In any case, I still think this slightly simplifies the code because the manual pipes created using `os.pipe2` are no longer needed (possibly related to #222).

I've snuck in two small formatting commits as well, since I didn't feel like creating a separate PR for that. :stuck_out_tongue: 