### PR TITLE
added notes after samples

### DIFF
--- a/latex/bapc.cls
+++ b/latex/bapc.cls
@@ -67,6 +67,7 @@
 \RequirePackage{float}
 \RequirePackage{listingsutf8}
 \RequirePackage{tocloft}
+\RequirePackage{xparse}
 
 \RequirePackage[hidelinks,bookmarks=true,pdfusetitle]{hyperref}
 
@@ -163,6 +164,14 @@
 \newenvironment{Explanation}{
 	\subsection*{Explanation of samples}
 }{}
+\def\notesContent{}
+\NewDocumentEnvironment{Notes}{+b}{}{
+	\gdef\notesContent{
+		\subsection*{Notes}
+		#1
+		\gdef\notesContent{}
+	}
+}
 
 %-------------------------------------------------------------------------------
 % Environment for specifying Samples.

--- a/latex/bapc.cls
+++ b/latex/bapc.cls
@@ -150,7 +150,7 @@
 
 
 %-------------------------------------------------------------------------------
-% Environments for specifying Input, Output and optionally Explanation.
+% Environments for specifying Input, Output, Interaction, and sample Explanation/Notes.
 %-------------------------------------------------------------------------------
 \newenvironment{Input}{
 	\subsection*{Input}
@@ -164,6 +164,9 @@
 \newenvironment{Explanation}{
 	\subsection*{Explanation of samples}
 }{}
+% Use xparse to get the contents of the environment as a variable (using `+b`) and store
+% them with the heading in `\notesContent`, which is automatically rendered at
+% the end of each problem. `gdef` overwrites the global definition of `notesContent`.
 \def\notesContent{}
 \NewDocumentEnvironment{Notes}{+b}{}{
 	\gdef\notesContent{

--- a/latex/contest-problem.tex
+++ b/latex/contest-problem.tex
@@ -5,6 +5,7 @@
     \renewcommand{\timelimit}{{%timelimit%}}
     \input{{%problemdir%}/problem_statement/problem.en.tex}
     \input{{%builddir%}/samples.tex}
+    \notesContent{}
     \renewcommand{\problemlabel}{}
     \renewcommand{\problemyamlname}{}
     \renewcommand{\problemauthor}{}

--- a/latex/problem.tex
+++ b/latex/problem.tex
@@ -7,5 +7,6 @@
     \renewcommand{\timelimit}{{%timelimit%}}
     \input{{%problemdir%}/problem_statement/problem.en.tex}
     \input{{%builddir%}/samples.tex}
+    \notesContent{}
 \endgroup
 \end{document}

--- a/test/problems/identity/problem_statement/problem.en.tex
+++ b/test/problems/identity/problem_statement/problem.en.tex
@@ -14,3 +14,7 @@ Given $n$, print $n$.
 \begin{Output}
     Output a single line containing $n$.
 \end{Output}
+
+\begin{Notes}
+	This is printed after the samples.
+\end{Notes}


### PR DESCRIPTION
This is a bit hacky but works...

tldr:
use `\begin{Notes} ... \end{Notes}` to add notes after the samples. This is done by storing the environment content in a variable that's rendered at the end
