### PR TITLE
Support FreeBSD & aquaBSD

### DIFF
--- a/bin/util.py
+++ b/bin/util.py
@@ -31,6 +31,18 @@ def is_mac():
     return sys.platform in ['darwin']
 
 
+def is_freebsd():
+    return "freebsd" in sys.platform
+
+
+def is_aquabsd():
+    return "aquabsd" in sys.platform
+
+
+def is_bsd():
+    return is_mac() or is_freebsd() or is_aquabsd()
+
+
 if not is_windows():
     import resource
 
@@ -716,7 +728,7 @@ def limit_setter(command, timeout, memory_limit):
             resource.setrlimit(resource.RLIMIT_CPU, (timeout + 1, timeout + 1))
 
         # Increase the max stack size from default to the max available.
-        if not is_mac():
+        if not is_bsd():
             resource.setrlimit(
                 resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY)
             )

--- a/bin/util.py
+++ b/bin/util.py
@@ -736,7 +736,7 @@ def limit_setter(command, timeout, memory_limit):
         if (
             memory_limit
             and not Path(command[0]).name in ['java', 'javac', 'kotlin', 'kotlinc']
-            and not is_mac()
+            and not is_bsd()
         ):
             resource.setrlimit(
                 resource.RLIMIT_AS, (memory_limit * 1024 * 1024, memory_limit * 1024 * 1024)


### PR DESCRIPTION
Replaces use of `is_mac()` with `is_bsd()` (which is a superset of `is_mac()`), as we don't want to limit stack/virtual memory usage on both systems.