### PR TITLE
reimplemented parallel

### DIFF
--- a/bin/parallel.py
+++ b/bin/parallel.py
@@ -40,7 +40,7 @@ class Parallel:
         while True:
             with self.mutex:
                 # if self.abort we need no item in the queue and can stop
-                # if self.finifh we may need to wake up if all tasks were completed earlier
+                # if self.finish we may need to wake up if all tasks were completed earlier
                 # else we need an item to handle
                 self.todo.wait_for(lambda: len(self.tasks) > 0 or self.abort or self.finish)
                 
@@ -54,8 +54,8 @@ class Parallel:
                     # get item from queue (update self.missing after the task is done)
                     task = self.tasks.pop(0)
             
-            # call f and catch all exeption occuring in f
-            # store the first expetion for later
+            # call f and catch all exceptions occurring in f
+            # store the first exception for later
             try:
                 current_error = None
                 self.f(task)
@@ -82,7 +82,7 @@ class Parallel:
 
         with self.mutex:
             # no task should be added after .done() was called
-            assert(not self.finish)
+            assert not self.finish
             # no task will be handled after self.abort anyway so 
             # we can skip adding
             if not self.abort:

--- a/bin/parallel.py
+++ b/bin/parallel.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import queue
 import threading
 import signal
 
@@ -12,12 +11,18 @@ class Parallel:
     # num_threads: True: the configured default
     #              None/False/0: disable parallelization
     def __init__(self, f, num_threads=True):
-        self.q = queue.Queue()
-        self.error = None
         self.f = f
-        self.stopping = False
-
         self.num_threads = config.args.jobs if num_threads is True else num_threads
+
+        self.mutex = threading.Lock()
+        self.todo = threading.Condition(self.mutex)
+        self.all_done = threading.Condition(self.mutex)
+
+        self.first_error = None
+        self.tasks = []
+        self.missing = 0
+        self.abort = False
+        self.finish = False
 
         if self.num_threads:
             self.threads = []
@@ -29,67 +34,82 @@ class Parallel:
             signal.signal(signal.SIGINT, self._interrupt_handler)
 
     def _worker(self):
-        try:
-            while not self.stopping:
-                task = self.q.get()
-                if task is None:
+        while True:
+            with self.mutex:
+                if len(self.tasks) == 0:
+                    self.todo.wait_for(lambda: len(self.tasks) > 0 or self.abort or self.finish)
+                
+                if self.abort or len(self.tasks) == 0:
                     break
+                else:
+                    task = self.tasks.pop(0)
+            
+            try:
+                current_error = None
                 self.f(task)
-                self.q.task_done()
-        except Exception as e:
-            self.stop()
-            if not self.error:
-                self.error = e
+            except Exception as e:
+                self.stop()
+                current_error = e
+
+            with self.mutex:
+                if not self.first_error:
+                    self.first_error = current_error
+                self.missing -= 1
+                if self.missing == 0:
+                    self.all_done.notify_all()
 
     def _interrupt_handler(self, sig, frame):
         util.fatal('Running interrupted')
 
     # Add one task.
     def put(self, task):
-        if self.stopping:
+        if not self.num_threads:
+            self.f(task)
             return
 
-        if self.num_threads:
-            self.q.put(task)
-        else:
-            self.f(task)
+        with self.mutex:
+            assert(not self.finish)
+            if not self.abort:
+                self.missing += 1
+                self.tasks.append(task)
+                self.todo.notify()
 
     def join(self):
-        if self.error:
-            raise self.error
-        self.q.join()
-        if self.error:
-            raise self.error
+        if not self.num_threads:
+            return
+
+        with self.all_done:
+            if self.missing > 0:
+                self.all_done.wait_for(lambda: self.missing == 0)
+            if self.first_error:
+                raise self.first_error
 
     # Wait for all tasks to be done and stop all threads
     def done(self):
         if not self.num_threads:
             return
 
-        for _ in range(self.num_threads):
-            self.q.put(None)
+        with self.todo:
+            self.finish = True
+            self.todo.notify_all()
 
         for t in self.threads:
             t.join()
 
-        if self.error is not None:
-            raise self.error
+        # mutex is no longer needed
+        if self.first_error is not None:
+            raise self.first_error
 
     # Discard all remaining work in the queue and stop all workers.
     # Call done() to join the threads.
     def stop(self):
-        if self.stopping:
-            return
-
-        self.stopping = True
-
         if not self.num_threads:
             return
 
-        try:
-            while True:
-                self.q.get(block=False)
-        except queue.Empty:
-            pass
-        for _ in range(self.num_threads):
-            self.q.put(None)
+        with self.mutex:
+            self.missing -= len(self.tasks)
+            self.tasks = []
+            self.abort = True
+            self.todo.notify_all()
+            if self.missing == 0:
+                self.all_done.notify_all()

--- a/bin/parallel.py
+++ b/bin/parallel.py
@@ -36,8 +36,7 @@ class Parallel:
     def _worker(self):
         while True:
             with self.mutex:
-                if len(self.tasks) == 0:
-                    self.todo.wait_for(lambda: len(self.tasks) > 0 or self.abort or self.finish)
+                self.todo.wait_for(lambda: len(self.tasks) > 0 or self.abort or self.finish)
                 
                 if self.abort or len(self.tasks) == 0:
                     break
@@ -79,8 +78,7 @@ class Parallel:
             return
 
         with self.all_done:
-            if self.missing > 0:
-                self.all_done.wait_for(lambda: self.missing == 0)
+            self.all_done.wait_for(lambda: self.missing == 0)
             if self.first_error:
                 raise self.first_error
 


### PR DESCRIPTION
The current implementation has `q.get()` operations with unmatched `q.task_done()` operations which leads to infinite waits if `q.join()` is called.

- in line 36, we break without 'q.task_done()'
- in line 39, we don't call  'q.task_done()' if an exception occurred 
- in line 91, we clear the queue without 'q.task_done()'

but even if these are added we have the variables `self.stopping` and `self.error` on which race conditions can occur. The `self.error` variable is no problem but a race condition on `self.stopping` in line 82 could lead to `2*num_threads` `None`s getting pushed in the queue. Which would break `q.join()` again.

Therefore, I propose a new implementation with a lock to prevent such race conditions (This lock also allows to do all other synchronization required).