### PR TITLE
Interaction

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -534,7 +534,7 @@ class Submission(program.Program):
                 bar.count = None
                 p.stop()
 
-        p = parallel.Parallel(lambda run: process_run(run, p), not self.problem.interactive)
+        p = parallel.Parallel(lambda run: process_run(run, p))
 
         for run in runs:
             p.put(run)

--- a/bin/util.py
+++ b/bin/util.py
@@ -722,7 +722,7 @@ class ExecResult:
         return self.verdict
 
 
-def limit_setter(command, timeout, memory_limit):
+def limit_setter(command, timeout, memory_limit, group=None):
     def setlimits():
         if timeout:
             resource.setrlimit(resource.RLIMIT_CPU, (timeout + 1, timeout + 1))
@@ -741,6 +741,12 @@ def limit_setter(command, timeout, memory_limit):
             resource.setrlimit(
                 resource.RLIMIT_AS, (memory_limit * 1024 * 1024, memory_limit * 1024 * 1024)
             )
+
+        if group is not None:
+            assert not is_windows()
+            assert not is_wsl()
+            assert not is_bsd()
+            os.setpgid(0, group)
 
         # Disable coredumps.
         resource.setrlimit(resource.RLIMIT_CORE, (0, 0))

--- a/bin/util.py
+++ b/bin/util.py
@@ -744,8 +744,7 @@ def limit_setter(command, timeout, memory_limit, group=None):
 
         if group is not None:
             assert not is_windows()
-            assert not is_wsl()
-            assert not is_bsd()
+            assert not is_mac()
             os.setpgid(0, group)
 
         # Disable coredumps.


### PR DESCRIPTION
Allow judging interactive programs in parallel by using `wait4` instead of `wait3`