### PR TITLE
Align semantics of `input_validator_flags: foo`

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -112,20 +112,11 @@ class Testcase:
         )
         if key not in self.testdata_yaml:
             return None
-        data = self.testdata_yaml[key]
-        if isinstance(data, str):
-            data = {'name': data}
-        if isinstance(data, dict):
-            data = [data]
-        for d in data:
-            if d['name'] == validator.path.name:
-                if 'flags' in d:
-                    # Split the string into a list of arguments.
-                    return d['flags'].split()
-                return None
-
-        # Configuration was found but this validator was not listed.
-        return False
+        flags = self.testdata_yaml[key]
+        # Note: support for lists/dicts for was removed in #259.
+        if not isinstance(flags, str):
+            fatal(f'{key} must be a string in testdata.yaml')
+        return flags.split()
 
     # Returns a dict of objects
     # hash =>


### PR DESCRIPTION
(Original issue by @thorehusfeldt converted to PR.)

After some headscratching, I have realised that BAPCtools disagrees with the problemtools toolchain about a fundamental issue, namely what `input_validator_flags` should mean. This currently means that BAPCtools cannot verify problems following the other tradition. I’ve tried to summarise my understand of the current situation in https://github.com/Kattis/problem-package-format/issues/25 and https://github.com/Kattis/problem-package-format/issues/26 , but for now I would just want to reestablish shared understanding of semantics and ensure basic functionality. 

A simple 3-line fix is this, in `bin.run` L 115:
```python
if config.args.input_validator_flags_are_args:
    return data.split()
else:
    data = {'name': data}
 ```
 Then the variable `input_validator_flags_are_args` can be set, for instance in `.bapctools.yaml` for a whole contest, and we could verify using both toolchains. (More dramatically, one could add `--input_validator_flags_are_args` to `bt validate`.)