### PR TITLE
Consistently use /usr/bin/env in shebangs

### DIFF
--- a/bin/misc/merge_scoreboards.sh
+++ b/bin/misc/merge_scoreboards.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Merge scoreboards using the DOMjudge socreboard:merge tool.
 # Run `sudo docker-compose up` in the domjudge git repo before running this script.

--- a/skel/multiple_validators/build
+++ b/skel/multiple_validators/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Build the required validators.
 # Modify to your likings.

--- a/skel/multiple_validators/run
+++ b/skel/multiple_validators/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # There is usually no need to modify this script!
 

--- a/test/problems/boolfind/output_validators/boolfind_run/build
+++ b/test/problems/boolfind/output_validators/boolfind_run/build
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gcc -g -O1 -Wall -fstack-protector -D_FORTIFY_SOURCE=2 -fPIE -Wformat -Wformat-security -ansi -pedantic runjury_boolfind.c -o jury

--- a/test/problems/boolfind/output_validators/boolfind_run/run
+++ b/test/problems/boolfind/output_validators/boolfind_run/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 TESTIN="$1";  shift
 TESTANS="$1"; shift
 FEEDBACKDIR="$1"; shift

--- a/test/problems/hello/submissions/rejected/test-extra-binary.sh/abc.sh
+++ b/test/problems/hello/submissions/rejected/test-extra-binary.sh/abc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This program tries to execute a submitted version of 'bc'. Although
 # this in itself is not very harmful (in a chroot, bc is probably

--- a/test/problems/identity/generators/dir_build/build
+++ b/test/problems/identity/generators/dir_build/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cat > run <<DOC
 #!/usr/bin/env python3

--- a/test/problems/identity/generators/dir_build_run/build
+++ b/test/problems/identity/generators/dir_build_run/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cat > main.py <<DOC
 #!/usr/bin/env python3

--- a/test/problems/identity/generators/dir_build_run/run
+++ b/test/problems/identity/generators/dir_build_run/run
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 python3 $(dirname $0)/main.py $1

--- a/test/problems/identity/visualizers/run
+++ b/test/problems/identity/visualizers/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 


### PR DESCRIPTION
Follow-up of https://github.com/RagnarGrootKoerkamp/BAPCtools/pull/282#issuecomment-1618983564.