### PR TITLE
Fix some frenchy errors

### DIFF
--- a/latex/bapc.cls
+++ b/latex/bapc.cls
@@ -333,6 +333,8 @@
 % The following are required for the overall layout:
 %-------------------------------------------------------------------------------
 \let\sffamilyFB\sffamily% Prevent error if babel fr loads \sffamilyFB in cache
+\let\ttfamilyFB\ttfamily
+\let\rmfamilyFB\rmfamily
 \usepackage[\langbabel]{babel}
 \usepackage{lmodern}
 \usepackage{graphicx}

--- a/latex/bapc.cls
+++ b/latex/bapc.cls
@@ -332,6 +332,7 @@
 %-------------------------------------------------------------------------------
 % The following are required for the overall layout:
 %-------------------------------------------------------------------------------
+\let\sffamilyFB\sffamily% Prevent error if babel fr loads \sffamilyFB in cache
 \usepackage[\langbabel]{babel}
 \usepackage{lmodern}
 \usepackage{graphicx}

--- a/latex/lang/fr.tex
+++ b/latex/lang/fr.tex
@@ -1,7 +1,7 @@
 \newcommand{\langbabel}{french}
 
 % bapc.cls
-\newcommand{\langblank}{Cette page est intentionnellement laissée vierge.}
+\newcommand{\langblank}{Cette page est intentionnellement laissée vide.}
 \newcommand{\langtimelimitmissing}{LIMITE DE TEMPS MANQUANTE}
 \newcommand{\langproblemname}{Nom du problème}
 \newcommand{\langproblemauthor}{Auteur du problème}


### PR DESCRIPTION
Hello !

I was experimenting the new language feature (#256) and noticed a weird error the second time I called `bt pdf` (not the first time) :
```
! Undefined control sequence.
<argument> ...{ \vspace {.4pt} \hfill \sffamilyFB 
                                                  \relax \fontsize {14.4}{18...
l.1 ...itel][l]{Allumettes}\hfill }{}{section.0.1}
                                                  
!  ==> Fatal error occurred, no output PDF file produced!
```

After some investigations, I found out that the babel package set up in French renames all `\sffamily` to `\sffamilyFB`, so once I compile in French, some cache files (more precisely .aux and .lop) contain this new command and are not updated anymore to gain some time. However, the `sffamilyFB` command does not exist with babel en, de, nl, da.

That is why I PR this to force `sffamilyFB` to be defined to handle cache latex files if French has previously been used.

I haven't noticed anything wrong with other languages yet (nl, fr, en, da, de) but we should keep this babel behavior in mind.