### PR TITLE
[export] update_problems_yaml: Write `name` as `str` instead of `dict`

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -248,7 +248,7 @@ def export_contest():
                 # (YAML 1.2 parses it as a string.)
                 if isinstance(value, int):
                     str(datetime.timedelta(seconds=data[key]))
-                data[key] = value;
+                data[key] = value
 
     verbose("Uploading contest.yaml:")
     verbose(data)
@@ -296,7 +296,17 @@ def update_problems_yaml(problems, colors=None):
         for d in data:
             if d['id'] == problem.name:
                 found = True
-                if problem.settings.name and problem.settings.name != d.get('name'):
+                default_language = (
+                    'en'
+                    if 'en' in problem.statement_languages
+                    else next(iter(problem.statement_languages), None)
+                )
+                problem_name = (
+                    problem.settings.name
+                    and default_language
+                    and problem.settings.name[default_language]
+                )
+                if problem_name != d.get('name'):
                     change = True
                     d['name'] = problem.settings.name
 


### PR DESCRIPTION
Follow-up of #256 (#109).

When running `bt update_problems_yaml`, the contest's `problems.yaml` looked like this:
```yaml
- id: helloworld
  label: A
  name: 
    en: Hello World
  rgb: '#000000'
  time_limit: 1.0
```
However, DOMjudge doesn't eat this yet ([source](https://github.com/DOMjudge/domjudge/blob/main/webapp/src/Service/ImportExportService.php#L290)). Therefore, I propose that the `name` key in `~contest/problems.yaml` remains a `str` instead of a `dict`.
No code changes are needed for `~problem/problem.yaml`, because there is no code that automatically updates it. The user can manually set `name` to be either a `dict` or a `str`, to their choice.

(My first attempt was to overwrite `problem.settings.name` to be a `str` in `Problem._determine_statement_languages` if the only language is English, but that would require extra branches in other places. So far, I think that `problems.yaml` is the only place where this distinction matters, so I switched to the approach of only converting the name back to a `str` in `update_problems_yaml`.)