### PR TITLE
Update and improve JSON schema

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,4 +6,5 @@ jobs:
     container: ragnargrootkoerkamp/bapctools
     steps:
       - uses: actions/checkout@v2
+      - run: cue vet doc/generators.yaml support/schemas/*cue -d '#Generators'
       - run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN pacman -Syu --noconfirm \
 	pacman -Scc --noconfirm
 RUN git clone https://github.com/RagnarGrootKoerkamp/BAPCtools /opt/bapctools && \
     ln -sfn /opt/bapctools/bin/tools.py /usr/bin/bt && ln -sfn /opt/bapctools/third_party/checktestdata /usr/bin/checktestdata
+# TODO: Replace by installing cue package once that's on 0.6.0
+COPY cue /usr/bin/cue
 RUN mkdir /data
 WORKDIR /data
 ENTRYPOINT ["/bin/bt"]

--- a/doc/generators.yaml
+++ b/doc/generators.yaml
@@ -65,9 +65,8 @@ generators:
   b:
     - b.cpp
   # It is allowed, but not required, to explicitly list single-file generators
-  # as well. It is allowed to reuse the same name, but introducing a new name is
-  # also fine.
-  c.py:
+  # as well. Names must not contain `.`, so `c.py` as a name is disallowed here.
+  cpy:
     - c.py
     - lib.py
 
@@ -113,12 +112,12 @@ data:
   secret:
     data:
       # Types of generator programs.
-      "01": 
+      "01":
         in: "3" # string is written to 01.in.
       "02": greedy.cpp 4 # c++ is compiled, just like validators, and the resulting binary is run with argument `4`.
       "03": dir 5 # directories are OK, just like validators
       "04": tree 5 # keys from the global generators: dictionary may also be used.
-      "05": 
+      "05":
         generate: tree 6 # same as above, but with different argument
 
       # Arguments are split on white space: this will pass two arguments: `"a` and `b"`, so probably not what is intended.

--- a/support/schemas/generators.cue
+++ b/support/schemas/generators.cue
@@ -22,7 +22,7 @@ casename: =~"^\(basename)$"
 let filename = "[A-Za-z0-9][A-Za-z0-9_.-]*[A-Za-z0-9]"
 
 filepath: =~"^/?\(filename)(/\(filename))*$"
-casepath: =~"^/?\(filename)(/\(basename))*$"
+casepath: =~"^\(filename)(/\(basename))*$"
 
 #config: {
 	"testdata.yaml"?: #testdata_settings
@@ -39,7 +39,7 @@ casepath: =~"^/?\(filename)(/\(basename))*$"
 		generate?: command
 		// The "copy" key uses a path relative to "/generators/" ending in a testcase name,
 		// such as "manual/samples/3".
-		copy?:                            casepath & !~"^/"
+		copy?:                            casepath
 		["in" | "ans" | "desc" | "hint"]: string
 		#config
 	}
@@ -57,7 +57,7 @@ casepath: =~"^/?\(filename)(/\(basename))*$"
 	// Generators are named like files or testcases, like "tree.py" or "a".
 	// Each consists of a list of paths relative to "/generators/",
 	// such as "tree_generator/tree.h".
-	generators?: [casename | =~"^\(filename)$"]: [...(filepath & !~"^/")]
+	generators?: [casename]: [...(filepath & !~"^/")]
 	data: {
 		sample!:         #testgroup
 		secret!:         #testgroup

--- a/support/schemas/generators.cue
+++ b/support/schemas/generators.cue
@@ -11,12 +11,12 @@ import "struct"
 // to things like "tree --random --seed {seed:5}"
 command: !="" & (=~"^[^{}]*(\\{(name|seed(:[0-9]+)?)\\}[^{}]*)*$")
 
-// Testgroup and testcase names are alphanumerical with underscores
-// and hyphens; such as "huge" or "3" or "connected_graph-01".
+// Names for generators, testgroups, and testcases are alphanumerical with underscores
+// and hyphens; such as "huge", "make_tree", "3", or "connected_graph-01".
 let basename = "([A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]|[A-Za-z0-9])"
-casename: =~"^\(basename)$"
+name: =~"^\(basename)$"
 
-// Filenames are somewhat like casenames, but can also contain '.' 
+// Filenames are somewhat like names, but can also contain '.' 
 // and have length at least 2, such as "good-solution_02.py"
 // but not "huge_" or "a".
 let filename = "[A-Za-z0-9][A-Za-z0-9_.-]*[A-Za-z0-9]"
@@ -44,12 +44,12 @@ casepath: =~"^\(filename)(/\(basename))*$"
 		#config
 	}
 
-#data_dict: {[casename]: #testgroup | #testcase}
-#data_list: {[casename | ""]: #testgroup | #testcase} & struct.MinFields(1) & struct.MaxFields(1)
+#data_dict: {[name]: #testgroup | #testcase}
+#data_list: {[name | ""]: #testgroup | #testcase} & struct.MinFields(1) & struct.MaxFields(1)
 
 #testgroup: {
 	data?: #data_dict | [...#data_list]
-	include?: [...casename]
+	include?: [...name]
 	#config
 }
 
@@ -57,7 +57,7 @@ casepath: =~"^\(filename)(/\(basename))*$"
 	// Generators are named like files or testcases, like "tree.py" or "a".
 	// Each consists of a list of paths relative to "/generators/",
 	// such as "tree_generator/tree.h".
-	generators?: [casename]: [...(filepath & !~"^/")]
+	generators?: [name]: [...(filepath & !~"^/")]
 	data: {
 		sample!:         #testgroup
 		secret!:         #testgroup

--- a/support/schemas/generators_yaml_schema.json
+++ b/support/schemas/generators_yaml_schema.json
@@ -1,18 +1,27 @@
 {
-  "title": "Generator",
+  "title": "generator",
   "type": "object",
   "properties": {
     "solution": { "$ref": "#/$defs/solution" },
     "visualizer": { "$ref": "#/$defs/visualizer" },
     "random_salt": { "$ref": "#/$defs/random_salt" },
-    "generators": { "title": "Generators for this problem", "type": "object" },
+    "generators": { 
+      "title": "Generators", 
+      "description": "List of generators for this problem", 
+      "type": "object",
+      "patternProperties": {
+        "^[A-Za-z0-9_-]*$": { "title": "Generator", "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
     "data": {
-      "title": "Testdata root",
-      "description": "The root test group. Must contain the testgroups 'sample' and 'secret'.",
+      "title": "testdata root",
+      "description": "the root test group. must contain the testgroups 'sample' and 'secret'.",
       "type": "object",
       "properties": {
         "sample": { "$ref": "#/$defs/testgroup" },
         "secret": { "$ref": "#/$defs/testgroup" },
+        "invalid_inputs": { "$ref": "#/$defs/testgroup" },
         "testdata.yaml": { "$ref": "#/$defs/testdata_settings" }
       },
       "additionalProperties": false,
@@ -23,11 +32,10 @@
   "required": ["data"],
 
   "$defs": {
-
     "testgroup": {
       "type": "object",
-      "title": "Testgroup",
-      "description": "A testgroup",
+      "title": "Test Group",
+      "description": "A test group",
       "properties": {
         "data": {
           "description": "Commands or dictionaries defining the testdata in this testgroup",
@@ -40,12 +48,13 @@
           ]
         },
         "include": {
+          "title": "Inclusion",
           "type": "array",
-          "description": "Testcases and testgroups to be included in this testgroup from elsewhere.",
+          "description": "Test cases and test groups to be included in this testgroup from elsewhere.",
           "items": { "type": "string" }
         },
         "testdata.yaml": { "$ref": "#/$defs/testdata_settings" },
-        "solution": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
+        "solution": { "$ref": "#/$defs/solution" }
       },
       "additionalProperties": false
     },
@@ -53,7 +62,7 @@
     "testdata_settings": {
       "type": "object",
       "title": "Testdata settings",
-      "description": "Testdata settings for this testgroup. Will be copied to this testgroup's `testdata.yaml`.",
+      "description": "The settings that apply to the testdata for this test group. Will be copied to this testgroup's `testdata.yaml`.",
       "properties": {
         "on_reject": { "enum": ["break", "continue"], "default": "break" },
         "grading": { "enum": ["default", "custom"] },
@@ -66,40 +75,36 @@
     },
 
     "data_dict": {
+      "title": "Data Dictionary",
+      "description": "Defines the contents of a test group",
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z0-9_.-]*$": {
-          "oneOf": [
-            { "$ref": "#/$defs/testgroup" },
-            { "$ref": "#/$defs/testcase" },
-            { "type": "null" }
-          ]
-        }
+        "^[A-Za-z0-9_-]*$": { "oneOf": [ { "$ref": "#/$defs/testgroup" }, { "$ref": "#/$defs/testcase" } ] }
       },
       "additionalProperties": false,
       "minProperties": 1
     },
 
     "testcase": {
-      "title": "Testcase",
-      "description": "A testcase, i.e., a single instance to the problem.",
+      "title": "Test Case",
+      "description": "A test case, i.e., a single instance to the problem.",
       "oneOf": [
         { "$ref": "#/$defs/command" },
         {
-          "title": "Testcase dictionary",
-          "description": "Testcase creation dictionary.",
+          "title": "Test case dictionary",
+          "description": "Test case creation dictionary.",
           "type": "object",
           "properties": {
             "generate": { "$ref":  "#/$defs/command"},
             "copy": { "type": "string", 
               "title": "Copy", 
-              "description": "Copy this testcase from the given path relative to `generators/`.", 
+              "description": "Copy this testcase from the given path relative to `/generators/`.", 
               "examples": ["manual_cases/sample/3"] 
               },
-            "in": { "type": "string", "title": ".in", "description": "Explicit testcase input given as a string" },
-            "ans": { "type": "string", "title": ".ans", "description": "Explicit testcase answer given as a string" },
-            "desc": { "type": "string", "title": ".desc", "description": "Privileged information explaining the purpose of this testcase given as a string" },
-            "hint": { "type": "string", "title": ".hint", "description": "Feedback shown to the solver about this testcase given as a string"},
+            "in": { "type": "string", "title": "Input", "description": "Explicit input given as a string" },
+            "ans": { "type": "string", "title": "Default Answer", "description": "Explicit default answer given as a string" },
+            "desc": { "type": "string", "title": "Description", "description": "Privileged information explaining the purpose of this test case given as a string" },
+            "hint": { "type": "string", "title": "Hint", "description": "Feedback shown to the solver about this test case given as a string"},
             "visualizer": { "oneOf": [{"$ref": "#/$defs/visualizer"}, {"type": "null" }] },
             "random_salt": { "$ref": "#/$defs/random_salt" },
             "solution": {   "$ref": "#/$defs/solution" }
@@ -113,26 +118,26 @@
         "title": "Visualizer",
         "type": "string",
         "description": "Absolute path to a visualizer",
-        "examples": ["visualizers/asy.py"]
+        "examples": ["/visualizers/asy.py"]
       },
 
     "random_salt": {
-        "title": "Random salt",
+        "title": "Random Salt",
         "type": "string",
-        "description": "Salt to add to {seed} variables",
+        "description": "“Salt” to add to {seed} variables",
         "examples": ["abcd"]
       },
 
     "solution": {
         "type": "string",
-        "title": "Solution",
+        "title": "Default Solution",
         "description": "Absolute path to a solution for this problem or testcase.",
-        "examples": ["submissions/accepted/sol.py"]
+        "examples": ["/submissions/accepted/sol.py"]
       },
 
     "command": {
-      "title": "Generate",
-      "description": "Invoke of a generator to create this testcase",
+      "title": "Generator Invocation",
+      "description": "Invocation of a generator to create this testcase",
       "examples": ["forest --n 40 --connected", "path.cpp 20", "random {seed}"],
       "type": "string",
       "pattern": "^[^{}]*(\\{(name|seed(:[0-9]+)?)\\}[^{}]*)*$"

--- a/support/schemas/generators_yaml_schema.json
+++ b/support/schemas/generators_yaml_schema.json
@@ -2,15 +2,27 @@
   "title": "generator",
   "type": "object",
   "properties": {
-    "solution": { "$ref": "#/$defs/solution" },
-    "visualizer": { "$ref": "#/$defs/visualizer" },
-    "random_salt": { "$ref": "#/$defs/random_salt" },
-    "generators": { 
-      "title": "Generators", 
-      "description": "List of generators for this problem", 
+    "solution": {
+      "$ref": "#/$defs/solution"
+    },
+    "visualizer": {
+      "$ref": "#/$defs/visualizer"
+    },
+    "random_salt": {
+      "$ref": "#/$defs/random_salt"
+    },
+    "generators": {
+      "title": "Generators",
+      "description": "List of generators for this problem",
       "type": "object",
       "patternProperties": {
-        "^[A-Za-z0-9_-]*$": { "title": "Generator", "type": "array", "items": { "type": "string" } }
+        "^[A-Za-z0-9_-]*$": {
+          "title": "Generator",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "additionalProperties": false
     },
@@ -19,18 +31,30 @@
       "description": "the root test group. must contain the testgroups 'sample' and 'secret'.",
       "type": "object",
       "properties": {
-        "sample": { "$ref": "#/$defs/testgroup" },
-        "secret": { "$ref": "#/$defs/testgroup" },
-        "invalid_inputs": { "$ref": "#/$defs/testgroup" },
-        "testdata.yaml": { "$ref": "#/$defs/testdata_settings" }
+        "sample": {
+          "$ref": "#/$defs/testgroup"
+        },
+        "secret": {
+          "$ref": "#/$defs/testgroup"
+        },
+        "invalid_inputs": {
+          "$ref": "#/$defs/testgroup"
+        },
+        "testdata.yaml": {
+          "$ref": "#/$defs/testdata_settings"
+        }
       },
       "additionalProperties": false,
-      "required": ["sample", "secret"]
+      "required": [
+        "sample",
+        "secret"
+      ]
     }
   },
   "additionalProperties": true,
-  "required": ["data"],
-
+  "required": [
+    "data"
+  ],
   "$defs": {
     "testgroup": {
       "type": "object",
@@ -42,103 +66,193 @@
           "oneOf": [
             {
               "type": "array",
-              "items": { "allOf" : [{ "$ref": "#/$defs/data_dict" }, {"maxProperties": 1}] }
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/data_dict"
+                  },
+                  {
+                    "maxProperties": 1
+                  }
+                ]
+              }
             },
-            { "$ref": "#/$defs/data_dict" }
+            {
+              "$ref": "#/$defs/data_dict"
+            }
           ]
         },
         "include": {
           "title": "Inclusion",
           "type": "array",
           "description": "Test cases and test groups to be included in this testgroup from elsewhere.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
-        "testdata.yaml": { "$ref": "#/$defs/testdata_settings" },
-        "solution": { "$ref": "#/$defs/solution" }
+        "testdata.yaml": {
+          "$ref": "#/$defs/testdata_settings"
+        },
+        "solution": {
+          "$ref": "#/$defs/solution"
+        }
       },
       "additionalProperties": false
     },
-
     "testdata_settings": {
       "type": "object",
       "title": "Testdata settings",
       "description": "The settings that apply to the testdata for this test group. Will be copied to this testgroup's `testdata.yaml`.",
       "properties": {
-        "on_reject": { "enum": ["break", "continue"], "default": "break" },
-        "grading": { "enum": ["default", "custom"] },
-        "grader_flags": { "type": "string", "examples": ["min", "sum"]},
-        "input_validator_flags": { "type": "string" },
-        "accept_score": { "type": "string" },
-        "reject_score": { "type": "string" },
-        "range": { "type": "string" }
+        "on_reject": {
+          "enum": [
+            "break",
+            "continue"
+          ],
+          "default": "break"
+        },
+        "grading": {
+          "enum": [
+            "default",
+            "custom"
+          ]
+        },
+        "grader_flags": {
+          "type": "string",
+          "examples": [
+            "min",
+            "sum"
+          ]
+        },
+        "input_validator_flags": {
+          "type": "string"
+        },
+        "accept_score": {
+          "type": "string"
+        },
+        "reject_score": {
+          "type": "string"
+        },
+        "range": {
+          "type": "string"
+        }
       }
     },
-
     "data_dict": {
       "title": "Data Dictionary",
       "description": "Defines the contents of a test group",
       "type": "object",
       "patternProperties": {
-        "^[A-Za-z0-9_-]*$": { "oneOf": [ { "$ref": "#/$defs/testgroup" }, { "$ref": "#/$defs/testcase" } ] }
+        "^[A-Za-z0-9_-]*$": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/testgroup"
+            },
+            {
+              "$ref": "#/$defs/testcase"
+            }
+          ]
+        }
       },
       "additionalProperties": false,
       "minProperties": 1
     },
-
     "testcase": {
       "title": "Test Case",
       "description": "A test case, i.e., a single instance to the problem.",
       "oneOf": [
-        { "$ref": "#/$defs/command" },
+        {
+          "$ref": "#/$defs/command"
+        },
         {
           "title": "Test case dictionary",
           "description": "Test case creation dictionary.",
           "type": "object",
           "properties": {
-            "generate": { "$ref":  "#/$defs/command"},
-            "copy": { "type": "string", 
-              "title": "Copy", 
-              "description": "Copy this testcase from the given path relative to `/generators/`.", 
-              "examples": ["manual_cases/sample/3"] 
-              },
-            "in": { "type": "string", "title": "Input", "description": "Explicit input given as a string" },
-            "ans": { "type": "string", "title": "Default Answer", "description": "Explicit default answer given as a string" },
-            "desc": { "type": "string", "title": "Description", "description": "Privileged information explaining the purpose of this test case given as a string" },
-            "hint": { "type": "string", "title": "Hint", "description": "Feedback shown to the solver about this test case given as a string"},
-            "visualizer": { "oneOf": [{"$ref": "#/$defs/visualizer"}, {"type": "null" }] },
-            "random_salt": { "$ref": "#/$defs/random_salt" },
-            "solution": {   "$ref": "#/$defs/solution" }
+            "generate": {
+              "$ref": "#/$defs/command"
+            },
+            "copy": {
+              "type": "string",
+              "title": "Copy",
+              "description": "Copy this testcase from the given path relative to `/generators/`.",
+              "examples": [
+                "manual_cases/sample/3"
+              ]
+            },
+            "in": {
+              "type": "string",
+              "title": "Input",
+              "description": "Explicit input given as a string"
+            },
+            "ans": {
+              "type": "string",
+              "title": "Default Answer",
+              "description": "Explicit default answer given as a string"
+            },
+            "desc": {
+              "type": "string",
+              "title": "Description",
+              "description": "Privileged information explaining the purpose of this test case given as a string"
+            },
+            "hint": {
+              "type": "string",
+              "title": "Hint",
+              "description": "Feedback shown to the solver about this test case given as a string"
+            },
+            "visualizer": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/visualizer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "random_salt": {
+              "$ref": "#/$defs/random_salt"
+            },
+            "solution": {
+              "$ref": "#/$defs/solution"
+            }
           },
           "additionalProperties": false
         }
       ]
     },
-
     "visualizer": {
-        "title": "Visualizer",
-        "type": "string",
-        "description": "Absolute path to a visualizer",
-        "examples": ["/visualizers/asy.py"]
-      },
-
+      "title": "Visualizer",
+      "type": "string",
+      "description": "Absolute path to a visualizer",
+      "examples": [
+        "/visualizers/asy.py"
+      ]
+    },
     "random_salt": {
-        "title": "Random Salt",
-        "type": "string",
-        "description": "“Salt” to add to {seed} variables",
-        "examples": ["abcd"]
-      },
-
+      "title": "Random Salt",
+      "type": "string",
+      "description": "“Salt” to add to {seed} variables",
+      "examples": [
+        "abcd"
+      ]
+    },
     "solution": {
-        "type": "string",
-        "title": "Default Solution",
-        "description": "Absolute path to a solution for this problem or testcase.",
-        "examples": ["/submissions/accepted/sol.py"]
-      },
-
+      "type": "string",
+      "title": "Default Solution",
+      "description": "Absolute path to a solution for this problem or testcase.",
+      "examples": [
+        "/submissions/accepted/sol.py"
+      ]
+    },
     "command": {
       "title": "Generator Invocation",
       "description": "Invocation of a generator to create this testcase",
-      "examples": ["forest --n 40 --connected", "path.cpp 20", "random {seed}"],
+      "examples": [
+        "forest --n 40 --connected",
+        "path.cpp 20",
+        "random {seed}"
+      ],
       "type": "string",
       "pattern": "^[^{}]*(\\{(name|seed(:[0-9]+)?)\\}[^{}]*)*$"
     }

--- a/support/schemas/generators_yaml_schema.json
+++ b/support/schemas/generators_yaml_schema.json
@@ -21,7 +21,7 @@
           "title": "Generator",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/unslashedfilepath"
           }
         }
       },
@@ -224,11 +224,11 @@
     },
     "visualizer": {
       "title": "Visualizer",
-      "type": "string",
       "description": "Absolute path to a visualizer",
       "examples": [
         "/visualizers/asy.py"
-      ]
+      ],
+      "$ref": "#/$defs/slashedfilepath"
     },
     "random_salt": {
       "title": "Random Salt",
@@ -239,12 +239,12 @@
       ]
     },
     "solution": {
-      "type": "string",
       "title": "Default Solution",
       "description": "Absolute path to a solution for this problem or testcase.",
       "examples": [
         "/submissions/accepted/sol.py"
-      ]
+      ],
+      "$ref": "#/$defs/slashedfilepath"
     },
     "command": {
       "title": "Generator Invocation",
@@ -256,6 +256,18 @@
       ],
       "type": "string",
       "pattern": "^[^{}]*(\\{(name|seed(:[0-9]+)?)\\}[^{}]*)*$"
+    },
+    "slashedfilepath": {
+      "type": "string",
+      "pattern": "^/([A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]/)*[A-Za-z0-9][A-Za-z0-9_.-]*[A-Za-z0-9]$"
+    },
+    "unslashedfilepath": {
+      "type": "string",
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]/)*[A-Za-z0-9][A-Za-z0-9_.-]*[A-Za-z0-9]$"
+    },
+    "casepath": {
+      "type": "string",
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]/)*([A-Za-z0-9]|A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]$"
     }
   }
 }

--- a/support/schemas/generators_yaml_schema.json
+++ b/support/schemas/generators_yaml_schema.json
@@ -1,5 +1,6 @@
 {
-  "title": "generator",
+  "title": "Generator",
+  "description": "Generate test data for this prolem. Version 0.9.",
   "type": "object",
   "properties": {
     "solution": {
@@ -13,10 +14,10 @@
     },
     "generators": {
       "title": "Generators",
-      "description": "List of generators for this problem",
+      "description": "List of generators for this problem.",
       "type": "object",
       "patternProperties": {
-        "^[A-Za-z0-9_-]*$": {
+        "^([A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]|[A-Za-z0-9])$": {
           "title": "Generator",
           "type": "array",
           "items": {
@@ -143,7 +144,7 @@
       "description": "Defines the contents of a test group",
       "type": "object",
       "patternProperties": {
-        "^[A-Za-z0-9_-]*$": {
+        "^([A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]|[A-Za-z0-9]|)$": {
           "oneOf": [
             {
               "$ref": "#/$defs/testgroup"


### PR DESCRIPTION
* Specify generators (note: disallowing `c.py` as a name)
* Allow `data/invalid_inputs`
* Disallow `null` for `solution`
* Disallow empty testcase
* More correct example paths (in particular `/`)

Improved titles and descriptions