### PR TITLE
[parallel] If not num_threads, use queue instead of tail recursion

### DIFF
--- a/bin/fuzz.py
+++ b/bin/fuzz.py
@@ -88,9 +88,8 @@ class GeneratorTask:
                     return False
                 localbar.done()
             else:
-                if not target_ansfile.is_file():
-                    bar.error(f'{self.i}: {ansfile.name} does not exist and was not generated.')
-                    return False
+                bar.error(f'{self.i}: {ansfile.name} was not generated.')
+                return False
         else:
             if not testcase.ans_path.is_file():
                 testcase.ans_path.write_text('')

--- a/bin/fuzz.py
+++ b/bin/fuzz.py
@@ -188,25 +188,16 @@ class Fuzz:
         self.tasks = 0
         self.queue = parallel.Parallel(lambda task: task.run(bar), pin=True)
 
-        if self.queue.num_threads:
-            # pool of ids used for generators
-            self.tmp_ids = 2 * max(1, self.queue.num_threads) + 1
-            self.free_tmp_id = {*range(self.tmp_ids)}
-            self.tmp_id_count = [0] * self.tmp_ids
+        # pool of ids used for generators
+        self.tmp_ids = 2 * max(1, self.queue.num_threads) + 1
+        self.free_tmp_id = {*range(self.tmp_ids)}
+        self.tmp_id_count = [0] * self.tmp_ids
 
-            # add first generator task
-            self.finish_task()
+        # add first generator task
+        self.finish_task()
 
-            # wait for the queue to run empty (after config.args.time)
-            self.queue.join()
-        else:
-            self.tmp_ids = -1
-            while time.monotonic() - self.start_time <= config.args.time:
-                testcase_rule = self.testcase_rules[self.iteration % len(self.testcase_rules)]
-                self.iteration += 1
-                self.queue.put(GeneratorTask(self, testcase_rule, self.iteration, None))
-                self.queue.join()
-
+        # wait for the queue to run empty (after config.args.time)
+        self.queue.join()
         # At this point, no new tasks may be started anymore.
         self.queue.done()
         bar.done()

--- a/bin/fuzz.py
+++ b/bin/fuzz.py
@@ -186,7 +186,7 @@ class Fuzz:
         self.start_time = time.monotonic()
         self.iteration = 0
         self.tasks = 0
-        self.queue = parallel.Parallel(lambda task: task.run(bar), pin=True)
+        self.queue = parallel.new_queue(lambda task: task.run(bar), pin=True)
 
         # pool of ids used for generators
         self.tmp_ids = 2 * max(1, self.queue.num_threads) + 1

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1562,7 +1562,7 @@ class GeneratorConfig:
                 p.build(localbar)
                 localbar.done()
 
-            p = parallel.Parallel(build_program)
+            p = parallel.new_queue(build_program)
             for pr in programs:
                 p.put(pr)
             p.done()
@@ -1678,7 +1678,7 @@ class GeneratorConfig:
         #    after to deduplicate them against generated testcases.
 
         # 1
-        p = parallel.Parallel(lambda t: t.listed and t.generate(self.problem, self, bar))
+        p = parallel.new_queue(lambda t: t.listed and t.generate(self.problem, self, bar))
 
         def generate_dir(d):
             p.join()
@@ -1688,7 +1688,7 @@ class GeneratorConfig:
         p.done()
 
         # 2
-        p = parallel.Parallel(lambda t: not t.listed and t.generate(self.problem, self, bar))
+        p = parallel.new_queue(lambda t: not t.listed and t.generate(self.problem, self, bar))
 
         def generate_dir_unlisted(d):
             p.join()

--- a/bin/parallel.py
+++ b/bin/parallel.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-import threading
-import signal
 import heapq
-
 import os
+import signal
+import threading
 
 import config
 import util
 
 
-class ParallelItem:
+class QueueItem:
     def __init__(self, task, priority, id):
         self.task = task
         self.priority = priority
@@ -26,52 +25,21 @@ class ParallelItem:
             return self.id < other.id
 
 
-class Parallel:
-    # f(task): the function to run on each queue item.
-    # num_threads: True: the configured default
-    #              None/False/0: disable parallelization
-    def __init__(self, f, num_threads=True, pin=False):
+class AbstractQueue:
+    def __init__(self, f, pin):
         self.f = f
-        self.num_threads = config.args.jobs if num_threads is True else num_threads
-        self.pin = pin and not util.is_windows() and not util.is_bsd()
+        self.pin = pin
+        self.num_threads = 1
 
-        # mutex to lock parallel access
-        self.mutex = threading.RLock()
-        # condition used to notify worker if the queue has changed
-        self.todo = threading.Condition(self.mutex)
-        # condition used to notify join that the queue is empty
-        self.all_done = threading.Condition(self.mutex)
-
-        # only used in parallel mode
-        self.first_error = None
         # min heap
-        self.tasks = []
+        self.tasks: list[QueueItem] = []
         self.total_tasks = 0
         self.missing = 0
 
-        # also used if num_threads is false
         self.abort = False
-        self.finish = False
 
-        if self.num_threads:
-            if self.pin:
-                # only use available cores and reserve one
-                cores = list(os.sched_getaffinity(0))
-                if self.num_threads > len(cores) - 1:
-                    self.num_threads = len(cores) - 1
-
-                # sort cores by id. If num_threads << len(cores) this ensures that we
-                # use different physical cores instead of hyperthreads
-                cores.sort()
-
-            self.threads = []
-            for i in range(self.num_threads):
-                args = [{cores[i]}] if self.pin else []
-                t = threading.Thread(target=self._worker, args=args, daemon=True)
-                t.start()
-                self.threads.append(t)
-
-            signal.signal(signal.SIGINT, self._interrupt_handler)
+        # mutex to lock parallel access
+        self.mutex = threading.RLock()
 
     def __enter__(self):
         self.mutex.__enter__()
@@ -79,7 +47,83 @@ class Parallel:
     def __exit__(self, *args):
         self.mutex.__exit__(*args)
 
-    def _worker(self, cores=False):
+    # Add one task. Higher priority => done first
+    def put(self, task, priority=0):
+        raise "Abstract method"
+
+    # By default, do nothing on .join(). This is overridden in ParallelQueue.
+    def join(self):
+        return
+
+    def done(self):
+        raise "Abstract method"
+
+    def stop(self):
+        self.abort = True
+
+
+class SequentialQueue(AbstractQueue):
+    def __init__(self, f, pin):
+        super().__init__(f, pin)
+
+    # Add one task. Higher priority => done first
+    def put(self, task, priority=0):
+        # no task will be handled after self.abort so skip adding
+        if self.abort:
+            return
+
+        self.total_tasks += 1
+        heapq.heappush(self.tasks, QueueItem(task, priority, self.total_tasks))
+
+    # Execute all tasks.
+    def done(self):
+        if self.pin:
+            cores = list(os.sched_getaffinity(0))
+            os.sched_setaffinity(0, {cores[0]})
+
+        # no task will be handled after self.abort
+        while self.tasks and not self.abort:
+            self.f(heapq.heappop(self.tasks).task)
+
+        if self.pin:
+            os.sched_setaffinity(0, cores)
+
+
+class ParallelQueue(AbstractQueue):
+    def __init__(self, f, pin, num_threads):
+        super().__init__(f, pin)
+
+        assert num_threads and type(num_threads) is int
+        self.num_threads = num_threads
+
+        # condition used to notify worker if the queue has changed
+        self.todo = threading.Condition(self.mutex)
+        # condition used to notify join that the queue is empty
+        self.all_done = threading.Condition(self.mutex)
+
+        self.first_error = None
+        self.finish = False
+
+        if self.pin:
+            # only use available cores and reserve one
+            cores = list(os.sched_getaffinity(0))
+            if self.num_threads > len(cores) - 1:
+                self.num_threads = len(cores) - 1
+
+            # sort cores by id. If num_threads << len(cores) this ensures that we
+            # use different physical cores instead of hyperthreads
+            cores.sort()
+
+        self.threads = []
+        for i in range(self.num_threads):
+            args = [{cores[i]}] if self.pin else []
+            t = threading.Thread(target=self._worker, args=args, daemon=True)
+            t.start()
+            self.threads.append(t)
+
+        signal.signal(signal.SIGINT, self._interrupt_handler)
+
+    def _worker(self, cores: bool | list[int] = False):
         if cores is not False:
             os.sched_setaffinity(0, cores)
         while True:
@@ -121,29 +165,18 @@ class Parallel:
 
     # Add one task. Higher priority => done first
     def put(self, task, priority=0):
-        # no task should be added after .done() was called
-        assert not self.finish
-
-        # no task will be handled after self.abort so skip adding
-        if self.abort:
-            return
-
-        if not self.num_threads:
-            self.total_tasks += 1
-            heapq.heappush(self.tasks, ParallelItem(task, priority, self.total_tasks))
-            return
-
         with self.mutex:
-            # mark task as to be done and notify workers
-            self.missing += 1
-            self.total_tasks += 1
-            heapq.heappush(self.tasks, ParallelItem(task, priority, self.total_tasks))
-            self.todo.notify()
+            # no task should be added after .done() was called
+            assert not self.finish
+            # no task will be handled after self.abort so skip adding
+            if not self.abort:
+                # mark task as to be done and notify workers
+                self.missing += 1
+                self.total_tasks += 1
+                heapq.heappush(self.tasks, QueueItem(task, priority, self.total_tasks))
+                self.todo.notify()
 
     def join(self):
-        if not self.num_threads:
-            return
-
         # wait for all current task to be completed
         with self.all_done:
             self.all_done.wait_for(lambda: self.missing == 0)
@@ -152,24 +185,9 @@ class Parallel:
 
     # Wait for all tasks to be done and stop all threads
     def done(self):
-        if not self.num_threads:
-            # no task will be handled after self.abort
-            while self.tasks and not self.abort:
-                task = heapq.heappop(self.tasks)
-                if self.pin:
-                    cores = list(os.sched_getaffinity(0))
-                    os.sched_setaffinity(0, {cores[0]})
-                    self.f(task.task)
-                    os.sched_setaffinity(0, cores)
-                else:
-                    self.f(task.task)
-
         self.finish = True
 
-        if not self.num_threads:
-            return
-
-        # notify all workes with permission to leave main loop
+        # notify all workers with permission to leave main loop
         with self.todo:
             self.todo.notify_all()
 
@@ -178,17 +196,14 @@ class Parallel:
             t.join()
 
         # mutex is no longer needed
-        # report first error occured during execution
+        # report first error occurred during execution
         if self.first_error is not None:
             raise self.first_error
 
     # Discard all remaining work in the queue and stop all workers.
     # Call done() to join the threads.
     def stop(self):
-        self.abort = True
-
-        if not self.num_threads:
-            return
+        super().stop()
 
         with self.mutex:
             # drop all items in the queue at once
@@ -199,3 +214,16 @@ class Parallel:
             # notify .join() if queue runs empty
             if self.missing == 0:
                 self.all_done.notify_all()
+
+
+def new_queue(f, pin=False, num_threads=True):
+    # f(task): the function to run on each queue item.
+    # num_threads: True: the configured default
+    #              None/False/0: disable parallelization
+    num_threads = config.args.jobs if num_threads is True else num_threads
+    pin = pin and not util.is_windows() and not util.is_bsd()
+
+    if num_threads:
+        return ParallelQueue(f, pin, num_threads)
+    else:
+        return SequentialQueue(f, pin)

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -357,7 +357,7 @@ class Problem:
             p.build(localbar)
             localbar.done()
 
-        p = parallel.Parallel(build_program)
+        p = parallel.new_queue(build_program)
         for pr in programs:
             p.put(pr)
         p.done()
@@ -465,7 +465,7 @@ class Problem:
             build_ok &= p.build(localbar)
             localbar.done()
 
-        p = parallel.Parallel(build_program)
+        p = parallel.new_queue(build_program)
         for pr in validators:
             p.put(pr)
         p.done()

--- a/bin/run.py
+++ b/bin/run.py
@@ -325,7 +325,7 @@ class Submission(program.Program):
             bar.count = None
             p.stop()
 
-        p = parallel.Parallel(lambda run: process_run(run, p), pin=True)
+        p = parallel.new_queue(lambda run: process_run(run, p), pin=True)
 
         for run in runs:
             p.put(run)

--- a/bin/run.py
+++ b/bin/run.py
@@ -323,7 +323,7 @@ class Submission(program.Program):
                 return
 
             bar.count = None
-            p.stop()
+            p.abort()
 
         p = parallel.new_queue(lambda run: process_run(run, p), pin=True)
 


### PR DESCRIPTION
Previously, running `bt fuzz --jobs 0` would crash with a stack overflow after 244 iterations (±4 stack frames per iteration). This happened because after every GeneratorTask, a new task was started by calling Parallel.put, which in turn called its lambda, which called the new GeneratorTask, which called Parallel.put again in finish_task, etc.

I've rewritten the task handling in the case of `not num_threads` by moving it all to Parallel.done. Parallel.put now puts the task in the same priority queue as in the case where we _do_ want parallelism (num_threads > 0). The fuzzer should now be able to run more than 244 iterations again 😄

I created a PR instead of simply pushing to `master`, since I haven't touched all of this parallel stuff that often, so some extra eyes would be nice :slightly_smiling_face: 

<details>
<summary>To quickly reproduce the bug with `bt fuzz -j0`, I added a minimal generator to the test problem "hellowholeworld", which makes 244 iterations take about 2 minutes:</summary>

```diff
diff --git a/test/problems/hellowholeworld/generators/gen.py b/test/problems/hellowholeworld/generators/gen.py
new file mode 100644
index 0000000..829afc9
--- /dev/null
+++ b/test/problems/hellowholeworld/generators/gen.py
@@ -0,0 +1,6 @@
+#!/usr/bin/env python3
+import random
+import sys
+
+random.seed(sys.argv[1])
+print(random.randint(1, 100))
diff --git a/test/problems/hellowholeworld/generators/generators.yaml b/test/problems/hellowholeworld/generators/generators.yaml
new file mode 100644
index 0000000..2f90cce
--- /dev/null
+++ b/test/problems/hellowholeworld/generators/generators.yaml
@@ -0,0 +1,9 @@
+solution: /submissions/accepted/test-hello.py
+data:
+  sample:
+    data:
+      "1":
+        in: "1"
+  secret:
+    data:
+      - "": gen.py {seed}
```

</details>