### PR TITLE
display more debug paths

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -172,10 +172,10 @@ class GeneratorInvocation(Invocation):
         if result.ok is not True:
             if retries > 1:
                 bar.debug(f'{Style.RESET_ALL}-> {shorten_path(self.problem, cwd)}')
-                bar.error(f'generator failed {retry + 1} times', result.err)
+                bar.error(f'Generator failed {retry + 1} times', result.err)
             else:
                 bar.debug(f'{Style.RESET_ALL}-> {shorten_path(self.problem, cwd)}')
-                bar.error(f'generator failed', result.err)
+                bar.error(f'Generator failed', result.err)
 
         if result.ok is True and config.args.error and result.err:
             bar.log('stderr', result.err)
@@ -194,7 +194,7 @@ class VisualizerInvocation(Invocation):
 
         if result.ok == -9:
             bar.debug(f'{Style.RESET_ALL}-> {shorten_path(self.problem, cwd)}')
-            bar.error(f'Visualizer timeout after {result.duration}s')
+            bar.error(f'Visualizer TIMEOUT after {result.duration}s')
         elif result.ok is not True:
             bar.debug(f'{Style.RESET_ALL}-> {shorten_path(self.problem, cwd)}')
             bar.error('Visualizer failed', result.err)
@@ -219,10 +219,10 @@ class SolutionInvocation(Invocation):
 
         if result.ok == -9:
             bar.debug(f'{Style.RESET_ALL}-> {shorten_path(self.problem, cwd)}')
-            bar.error(f'solution TIMEOUT after {result.duration}s')
+            bar.error(f'Solution TIMEOUT after {result.duration}s')
         elif result.ok is not True:
             bar.debug(f'{Style.RESET_ALL}-> {shorten_path(self.problem, cwd)}')
-            bar.error('solution failed', result.err)
+            bar.error('Solution failed', result.err)
 
         if result.ok is True and config.args.error and result.err:
             bar.log('stderr', result.err)

--- a/bin/run.py
+++ b/bin/run.py
@@ -144,9 +144,9 @@ class Testcase:
 
             # Failure?
             if ret.ok is True:
-                message = 'Passed ' + validator.name
+                message = validator.name + ' passed'
             else:
-                message = 'Failed ' + validator.name
+                message = validator.name + ' failed'
 
             # Print stdout and stderr whenever something is printed
             data = ''
@@ -168,7 +168,7 @@ class Testcase:
                 if validator_type == 'output_format':
                     file = self.ans_path
                 data += (
-                    f'{Style.RESET_ALL}in {shorten_path(self.problem, file.parent) / file.name}\n'
+                    f'{Style.RESET_ALL}-> {shorten_path(self.problem, file.parent) / file.name}\n'
                 )
             else:
                 data = ret.err


### PR DESCRIPTION
This changes the following things:

- When generation fails clearly display what went wrong i.e. solution,visualization,generation...
- When generation fails and  `-v` is given display a shortened path to the tmp directory where generated stuff is
- Add the rule to the `meta_.yaml` to make it easier to find the failing rule in the `generator.yaml` (if auto numbering is used and multiple cases have the same base name this can be hard)