### PR TITLE
326 warn if problemtitle differs from problemsettingsnamelanguage

### DIFF
--- a/bin/latex.py
+++ b/bin/latex.py
@@ -356,3 +356,21 @@ def build_contest_pdfs(contest, problems, tmpdir, lang=None, solutions=False, we
     return all(
         build_contest_pdf(contest, problems, tmpdir, lang, solutions, web) for lang in languages
     )
+
+def get_argument_for_command(texfile, command):
+    """ Return the (whitespace-normalised) argument for the given command in the given texfile.
+    If texfile contains `\foo{bar  baz }`, returns the string 'bar baz'.
+    The command is given without backslash.
+
+
+    Assumptions:
+    the command and its argument are on the same line,
+    and that the argument contains no closing curly brackets.
+    """
+
+    for line in texfile:
+        regex = r"\\" + command + r"\{(.*)\}"
+        match = re.search(regex, line)
+        if match:
+            return ' '.join(match.group(1).split())
+    return None

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -78,7 +78,7 @@ class Problem:
             with open(self.path / 'problem_statement' / f'problem.{lang}.tex') as texfile:
                 match texname := latex.get_argument_for_command(texfile, 'problemname'):
                     case None:
-                        warn(rf"No \problemname found in problem.{lang}.tex")
+                        error(rf"No \problemname found in problem.{lang}.tex")
                         continue
                     case '\problemname':
                         continue

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -58,19 +58,19 @@ class Problem:
         """
         if isinstance(self.settings.name, str):
             self.settings.name = {'en': self.settings.name}
-        yamlnames = set(self.settings.name)
-        texfiles = set(
+        yamllangs = set(self.settings.name)
+        texlangs = set(
             path.suffixes[0][1:] for path in glob(self.path, 'problem_statement/problem.*.tex')
         )
-        for lang in texfiles - yamlnames:
+        for lang in texlangs - yamllangs:
             error(
                 f"{self.name}: Found problem.{lang}.tex, but no corresponding name in problem.yaml."
             )
-        for lang in yamlnames - texfiles:
+        for lang in yamllangs - texlangs:
             error(
                 f"{self.name}: Found name for language {lang} in problem.yaml, but not problem.{lang}.tex."
             )
-        return sorted(texfiles & yamlnames)
+        return sorted(texlangs & yamllangs)
 
     def _read_settings(self):
         # some defaults

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import config
+import latex
 import parallel
 import program
 import run
@@ -70,6 +71,18 @@ class Problem:
             error(
                 f"{self.name}: Found name for language {lang} in problem.yaml, but not problem.{lang}.tex."
             )
+        for lang in texlangs & yamllangs:
+            unnormalised_yamlname = self.settings.name[lang]
+            yamlname = ' '.join(unnormalised_yamlname.split())
+            with open(self.path / 'problem_statement' / f'problem.{lang}.tex') as texfile:
+                match tex_problem_name := latex.get_argument_for_command(texfile, 'problemname'):
+                    case None:
+                        warn(rf"No \problemname found in problem.{lang}.tex")
+                    case s if s not in ["\\problemyamlname", yamlname]:
+                        warn(f'Problem titles in problem.{lang}.tex ({tex_problem_name})' +
+                             f' and problem.yaml ({yamlname}) differ;' +
+                             r' consider using \problemname{\problemyamlname}.'
+                             )
         return sorted(texlangs & yamllangs)
 
     def _read_settings(self):

--- a/test/problems/boolfind/problem_statement/problem.en.tex
+++ b/test/problems/boolfind/problem_statement/problem.en.tex
@@ -1,0 +1,1 @@
+\problemname{\problemyamlname}

--- a/test/problems/different/problem.yaml
+++ b/test/problems/different/problem.yaml
@@ -1,5 +1,8 @@
 # problem.yaml
 
+
+name:
+  en: A Different Problem
 ## At least one of author, source, or rights_owner must be provided.
 ##
 ## Author of the problem (default: null)

--- a/test/problems/fltcmp/problem_statement/problem.en.tex
+++ b/test/problems/fltcmp/problem_statement/problem.en.tex
@@ -1,0 +1,1 @@
+\problemname{\problemyamlname}

--- a/test/problems/guess/problem.yaml
+++ b/test/problems/guess/problem.yaml
@@ -1,3 +1,5 @@
+name: 
+  en: Guess the Number
 source: Kattis
 license: cc by-sa
 

--- a/test/problems/hello/problem_statement/problem.en.tex
+++ b/test/problems/hello/problem_statement/problem.en.tex
@@ -1,0 +1,1 @@
+\problemname{\problemyamlname}

--- a/test/problems/hellounix/problem_statement/problem.en.tex
+++ b/test/problems/hellounix/problem_statement/problem.en.tex
@@ -1,0 +1,1 @@
+\problemname{\problemyamlname}

--- a/test/problems/test_problem_config/problem_statement/problem.en.tex
+++ b/test/problems/test_problem_config/problem_statement/problem.en.tex
@@ -1,0 +1,1 @@
+\problemname{\problemyamlname}


### PR DESCRIPTION
For #326, compare problemtitle in `problem.yaml` and various `{lang}.tex` files.

The extraction of `\problemname{foo}` in `problem.en.tex` is handled by a new method in `bin/latex.py`. This is very bare-bones and would be confused by each of the following

```tex
% \problenname{No warning produced, though outcommented}
```

```tex
\problemname{
   foo
}
```
Somebody should run this on a large repository of existing problems and see how many false positive warnings it generates.

It warns if no `problemname` is found in the tex source, which makes the BAPCtools testsuite unhappy. Maybe that warning shouldn’t be there. On the other hand, the specification actually requires it:

https://github.com/Kattis/problem-package-format/blob/af5288b5c21d8a65ace08296ce7aecad8fdefdd2/spec/2023-07-draft.md?plain=1#L282

(and in the first line of the code!) so maybe it should be much stricter.