### PR TITLE
fixes

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -23,6 +23,16 @@ PRIORITY = {
 
 VALIDATION_MODES = ['default', 'custom', 'custom interactive']
 
+KNOWN_LICENSES = [
+    'cc by-sa',
+    'cc by',
+    'cc0',
+    'public domain',
+    'educational',
+    'permission',
+    'unknown',
+]
+
 MAX_PRIORITY = max(PRIORITY.values())
 MAX_PRIORITY_VERDICT = [v for v in PRIORITY if PRIORITY[v] == MAX_PRIORITY]
 
@@ -46,13 +56,15 @@ KNOWN_DATA_EXTENSIONS = KNOWN_TESTCASE_EXTENSIONS + [
     '.jpg',
     '.svg',
     '.pdf',
-    '.gif',
+    #'.args',
+    #'.files', # this is actually a folder
 ]
 
 KNOWN_TEXT_DATA_EXTENSIONS = KNOWN_TESTCASE_EXTENSIONS + [
     '.interaction',
     '.hint',
     '.desc',
+    #'.args',
 ]
 
 INVALID_CASE_DIRECTORIES = [

--- a/bin/export.py
+++ b/bin/export.py
@@ -156,6 +156,7 @@ def build_problem_zip(problem, output, statement_language):
     # Build list of files to store in ZIP file.
     copyfiles = set()
 
+    # Include all files beside testcases
     for pattern, required in files:
         # Only include hidden files if the pattern starts with a '.'.
         paths = list(util.glob(problem.path, pattern, include_hidden=pattern[0] == '.'))
@@ -171,6 +172,7 @@ def build_problem_zip(problem, output, statement_language):
                     out = problem.name / out
                 copyfiles.add((f, out))
 
+    # Include all testcases (specified by a .in file) and copy all related files
     for pattern, required in testcases:
         paths = list(util.glob(problem.path, pattern))
         if required and len(paths) == 0:

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -29,6 +29,7 @@ class Problem:
         # The Path of the problem directory.
         self.path = path
         self.tmpdir = tmpdir / self.name
+        self.tmpdir.mkdir(parents=True, exist_ok=True)
         # Read problem.yaml and domjudge-problem.ini into self.settings Namespace object.
         self._read_settings()
 

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -71,10 +71,6 @@ def _ask_variable_choice(name, choices, default=None):
         return _ask_variable(name + text, default if default else '')
 
 
-def _license_choices():
-    return ['cc by-sa', 'cc by', 'cc0', 'public domain', 'educational', 'permission', 'unknown']
-
-
 # Returns the alphanumeric version of a string:
 # This reduces it to a string that follows the regex:
 # [a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]
@@ -101,7 +97,7 @@ def new_contest():
     testsession = _ask_variable_bool('testsession', False)
     year = _ask_variable_string('year', str(datetime.datetime.now().year))
     source_url = _ask_variable_string('source url', '', True)
-    license = _ask_variable_choice('license', _license_choices())
+    license = _ask_variable_choice('license', config.KNOWN_LICENSES)
     rights_owner = _ask_variable_string('rights owner', 'author')
     title = title.replace('_', '-')
 
@@ -153,11 +149,11 @@ def new_problem():
 
     validator_flags = ''
     if config.args.validation:
-        assert config.args.validation in ['default', 'custom', 'custom interactive']
+        assert config.args.validation in config.VALIDATION_MODES
         validation = config.args.validation
     else:
         validation = _ask_variable_choice(
-            'validation', ['default', 'float', 'custom', 'custom interactive']
+            'validation', config.VALIDATION_MODES[:1] + ['float'] + config.VALIDATION_MODES[1:]
         )
         if validation == 'float':
             validation = 'default'
@@ -183,7 +179,7 @@ def new_problem():
         'source url', variables.get('source_url', ''), True
     )
     variables['license'] = _ask_variable_choice(
-        'license', _license_choices(), variables.get('license', None)
+        'license', config.KNOWN_LICENSES, variables.get('license', None)
     )
     variables['rights_owner'] = _ask_variable_string(
         'rights owner', variables.get('rights_owner', 'author')


### PR DESCRIPTION
this "fixes" a few things

- create tmpdir before writing .uuid 
- refactor licenses and use `VALIDATION_MODES`
- remove unofficial `.gif` support
- warn for deprecated files on export
- ensure that only testcase files including `.in` and `.ans` are exported
- include tescases for interactive problems