### PR TITLE
Change from path.resolve() to path.absolute()

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -78,10 +78,10 @@ INVALID_CASE_DIRECTORIES = [
 SEED_DEPENDENCY_RETRIES = 10
 
 # The root directory of the BAPCtools repository.
-tools_root = Path(__file__).resolve().parent.parent
+tools_root = Path(__file__).absolute().parent.parent
 
 # The directory from which BAPCtools is invoked.
-current_working_directory = Path.cwd().resolve()
+current_working_directory = Path.cwd().absolute()
 
 # Add third_party/ to the $PATH for checktestdata.
 os.environ["PATH"] += os.pathsep + str(tools_root / 'third_party')

--- a/bin/interactive.py
+++ b/bin/interactive.py
@@ -48,9 +48,9 @@ def run_interactive_testcase(
     validator_command = (
         output_validator.run_command
         + [
-            run.testcase.in_path.resolve(),
-            run.testcase.ans_path.resolve(),
-            run.feedbackdir.resolve(),
+            run.testcase.in_path.absolute(),
+            run.testcase.ans_path.absolute(),
+            run.feedbackdir.absolute(),
         ]
         + run.problem.settings.validator_flags
     )

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -25,7 +25,7 @@ class Problem:
 
     def __init__(self, path, tmpdir, label=None):
         # The problem name/shortname, which is the name of the directory and used as a display name.
-        self.name = path.resolve().name
+        self.name = path.absolute().name
         # The Path of the problem directory.
         self.path = path
         self.tmpdir = tmpdir / self.name

--- a/bin/program.py
+++ b/bin/program.py
@@ -106,8 +106,8 @@ class Program:
         # Ideally they are the same as the path inside the problem, but fallback to just the name.
         try:
             # Only resolve the parent of the program. This preserves programs that are symlinks to other directories.
-            relpath = (path.parent.resolve() / path.name).relative_to(
-                problem.path.resolve() / self.subdir
+            relpath = (path.parent.absolute() / path.name).relative_to(
+                problem.path.absolute() / self.subdir
             )
             self.short_path = relpath
             self.name = str(relpath)

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -301,7 +301,7 @@ def copy_skel_dir(problems):
 # NOTE: This is one of few places that prints to stdout instead of stderr.
 def create_gitlab_jobs(contest, problems):
     def problem_source_dir(problem):
-        return problem.path.resolve().relative_to(Path('..').resolve())
+        return problem.path.absolute().relative_to(Path('..').absolute())
 
     header_yml = (config.tools_root / 'skel/gitlab_ci/header.yaml').read_text()
     print(substitute(header_yml, locals()))

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -81,11 +81,11 @@ def get_problems():
     problem = None
     level = None
     if config.args.contest:
-        contest = config.args.contest.resolve()
+        contest = config.args.contest.absolute()
         os.chdir(contest)
         level = 'problemset'
     if config.args.problem:
-        problem = config.args.problem.resolve()
+        problem = config.args.problem.absolute()
         level = 'problem'
         os.chdir(problem.parent)
     elif is_problem_directory(Path('.')):

--- a/bin/util.py
+++ b/bin/util.py
@@ -660,7 +660,7 @@ def resolve_path_argument(problem, path, type, suffixes=[]):
 # If the provided path does not point to the tmpdir it is returned as is.
 # The path is of the form "tmp/<contest_tmpdir>/<problem_tmpdir>/links/<hash>"
 def shorten_path(problem, path):
-    if not path.resolve().is_relative_to(problem.tmpdir):
+    if not path.absolute().is_relative_to(problem.tmpdir):
         return path
     short_hash = hashlib.sha256(bytes(path)).hexdigest()[-6:]
     dir = problem.tmpdir / 'links'

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -154,7 +154,7 @@ class Validator(program.Program):
         if self.language == 'viva':
             # Called as `viva validator.viva testcase.in`.
             result = exec_command(
-                self.run_command + [main_path.resolve()],
+                self.run_command + [main_path.absolute()],
                 exec_code_map=format_exec_code_map,
                 cwd=cwd,
             )
@@ -240,7 +240,7 @@ class AnswerValidator(Validator):
         if self.language in Validator.FORMAT_VALIDATOR_LANGUAGES:
             return Validator._run_format_validator(self, testcase, cwd)
 
-        invocation = self.run_command + [testcase.in_path.resolve()]
+        invocation = self.run_command + [testcase.in_path.absolute()]
 
         with testcase.ans_path.open() as ans_file:
             ret = exec_command(
@@ -288,8 +288,8 @@ class OutputValidator(Validator):
         if mode == Mode.INPUT:
             raise ValueError("OutputValidator do no support Mode.INPUT")
 
-        in_path = testcase.in_path.resolve()
-        ans_path = testcase.ans_path.resolve()
+        in_path = testcase.in_path.absolute()
+        ans_path = testcase.ans_path.absolute()
         if hasattr(mode, 'out_path'):
             path = mode.out_path
         elif mode == Mode.ANSWER:
@@ -300,7 +300,7 @@ class OutputValidator(Validator):
                 raise ValueError(
                     "OutputValidator in Mode.INVALID should only be run for data/invalid_outputs"
                 )
-            path = testcase.out_path.resolve()
+            path = testcase.out_path.absolute()
 
         if self.language in Validator.FORMAT_VALIDATOR_LANGUAGES:
             raise ValueError("Invalid output validator language")

--- a/test/test_default_output_validator.py
+++ b/test/test_default_output_validator.py
@@ -13,7 +13,7 @@ import validate
 import util
 import config
 
-RUN_DIR = Path.cwd().resolve()
+RUN_DIR = Path.cwd().absolute()
 # Note: the python version isn't tested by default, because it's quite slow.
 DEFAULT_OUTPUT_VALIDATORS = ['default_output_validator.cpp']
 

--- a/test/test_problems.py
+++ b/test/test_problems.py
@@ -17,7 +17,7 @@ PROBLEMS = ['hello', 'helloproblemtools', 'different', 'fltcmp', 'boolfind', 'gu
 # Run various specific commands on this problem.
 IDENTITY_PROBLEMS = ['identity']
 
-RUN_DIR = Path.cwd().resolve()
+RUN_DIR = Path.cwd().absolute()
 
 
 @pytest.fixture(scope='class', params=PROBLEMS)


### PR DESCRIPTION
Usually we just need absolute paths for consistency, but we don't need to look through symlinks.

This would need some testing probably; I think it works but it's kinda tricky probably.