### PR TITLE
Testgroup verdicts

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -19,6 +19,13 @@ VERDICTS = [
     Verdict.COMPILER_ERROR,
 ]
 
+SUBMISSION_DIRS = [
+    'accepted',
+    'wrong_answer',
+    'time_limit_exceeded',
+    'run_time_error',
+]
+
 VALIDATION_MODES = ['default', 'custom', 'custom interactive']
 
 KNOWN_LICENSES = [

--- a/bin/config.py
+++ b/bin/config.py
@@ -16,6 +16,7 @@ VERDICTS = [
     Verdict.WRONG_ANSWER,
     Verdict.TIME_LIMIT_EXCEEDED,
     Verdict.RUNTIME_ERROR,
+    Verdict.COMPILER_ERROR,
 ]
 
 VALIDATION_MODES = ['default', 'custom', 'custom interactive']

--- a/bin/config.py
+++ b/bin/config.py
@@ -5,21 +5,18 @@ from pathlib import Path
 import re
 import os
 import argparse
+from verdicts import Verdict
 
 # return values
 RTV_AC = 42
 RTV_WA = 43
 
-VERDICTS = ['ACCEPTED', 'WRONG_ANSWER', 'TIME_LIMIT_EXCEEDED', 'RUN_TIME_ERROR']
-# Judging stops as soon as a max priority verdict is found.
-PRIORITY = {
-    'INCONSISTENT_VALIDATORS': -1,
-    'VALIDATOR_CRASH': -1,
-    'ACCEPTED': 0,
-    'WRONG_ANSWER': 90,
-    'TIME_LIMIT_EXCEEDED': 99,
-    'RUN_TIME_ERROR': 99,
-}
+VERDICTS = [
+    Verdict.ACCEPTED,
+    Verdict.WRONG_ANSWER,
+    Verdict.TIME_LIMIT_EXCEEDED,
+    Verdict.RUNTIME_ERROR,
+]
 
 VALIDATION_MODES = ['default', 'custom', 'custom interactive']
 
@@ -32,9 +29,6 @@ KNOWN_LICENSES = [
     'permission',
     'unknown',
 ]
-
-MAX_PRIORITY = max(PRIORITY.values())
-MAX_PRIORITY_VERDICT = [v for v in PRIORITY if PRIORITY[v] == MAX_PRIORITY]
 
 # When --table is set, this threshold determines the number of identical profiles needed to get flagged.
 TABLE_THRESHOLD = 4

--- a/bin/config.py
+++ b/bin/config.py
@@ -105,7 +105,7 @@ grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_
 grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
 # fmt: off
-args_list = ['1', 'all', 'add', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'directory', 'error', 'force', 'force_build', 'language', 'no_validators', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solutions', 'no_timelimit', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'no_solution', 'no_testcase_sanity_checks', 'no_visualizer', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'username', 'validation', 'watch', 'web']
+args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web']
 # fmt: on
 
 

--- a/bin/config.py
+++ b/bin/config.py
@@ -107,7 +107,7 @@ grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_
 grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
 # fmt: off
-args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'duration', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web']
+args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web']
 # fmt: on
 
 

--- a/bin/config.py
+++ b/bin/config.py
@@ -107,7 +107,7 @@ grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_
 grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
 # fmt: off
-args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web']
+args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'duration', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web']
 # fmt: on
 
 

--- a/bin/fuzz.py
+++ b/bin/fuzz.py
@@ -9,6 +9,7 @@ import parallel
 from util import *
 from testcase import Testcase
 from validate import OutputValidator, Mode
+from verdicts import Verdict
 
 # STEPS:
 # 1. Find generator invocations depending on {seed}.
@@ -132,7 +133,7 @@ class SubmissionTask:
         r = run.Run(self.generator_task.fuzz.problem, self.submission, self.testcase)
         localbar = bar.start(f'{self.generator_task.i}: {self.submission.name}')
         result = r.run(localbar)
-        if result.verdict != 'ACCEPTED':
+        if result.verdict != Verdict.ACCEPTED:
             self.generator_task.save_test(bar)
             localbar.done(False, f'{result.verdict}!')
         else:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -15,8 +15,9 @@ import inspect
 import parallel
 import program
 import run
-from testcase import Testcase
 import validate
+from testcase import Testcase
+from verdicts import Verdict
 
 from util import *
 
@@ -237,7 +238,7 @@ class SolutionInvocation(Invocation):
 
         # No {name}/{seed} substitution is done since all IO should be via stdin/stdout.
         ret = r.run(bar, interaction=interaction_path, submission_args=self.args)
-        if ret.verdict != 'ACCEPTED':
+        if ret.verdict != Verdict.ACCEPTED:
             bar.error(ret.verdict)
             return False
 

--- a/bin/interactive.py
+++ b/bin/interactive.py
@@ -6,6 +6,7 @@ import threading
 
 import config
 import validate
+from verdicts import Verdict
 
 from util import *
 
@@ -113,17 +114,17 @@ def run_interactive_testcase(
         print_verdict = None
         if validator_ok != config.RTV_AC and validator_ok != config.RTV_WA:
             config.n_error += 1
-            verdict = 'VALIDATOR_CRASH'
+            verdict = Verdict.VALIDATOR_CRASH
         elif did_timeout:
-            verdict = 'TIME_LIMIT_EXCEEDED'
+            verdict = Verdict.TIME_LIMIT_EXCEEDED
             if tend - tstart >= timeout:
                 print_verdict = 'TLE (aborted)'
         elif not exec_res.status:
-            verdict = 'RUN_TIME_ERROR'
+            verdict = Verdict.RUNTIME_ERROR
         elif validator_ok == config.RTV_WA:
-            verdict = 'WRONG_ANSWER'
+            verdict = Verdict.WRONG_ANSWER
         elif validator_ok == config.RTV_AC:
-            verdict = 'ACCEPTED'
+            verdict = Verdict.ACCEPTED
 
         if not validator_err:
             validator_err = bytes()
@@ -322,31 +323,31 @@ while True:
 
     print_verdict = None
     if aborted:
-        verdict = 'TIME_LIMIT_EXCEEDED'
+        verdict = Verdict.TIME_LIMIT_EXCEEDED
         print_verdict = 'TLE (aborted)'
     elif validator_status != config.RTV_AC and validator_status != config.RTV_WA:
         config.n_error += 1
-        verdict = 'VALIDATOR_CRASH'
+        verdict = Verdict.VALIDATOR_CRASH
     elif first == 'validator':
         # WA has priority because validator reported it first.
         if did_timeout:
-            verdict = 'TIME_LIMIT_EXCEEDED'
+            verdict = Verdict.TIME_LIMIT_EXCEEDED
         elif validator_status == config.RTV_WA:
-            verdict = 'WRONG_ANSWER'
+            verdict = Verdict.WRONG_ANSWER
         elif submission_status != 0:
-            verdict = 'RUN_TIME_ERROR'
+            verdict = Verdict.RUNTIME_ERROR
         else:
-            verdict = 'ACCEPTED'
+            verdict = Verdict.ACCEPTED
     else:
         assert first == 'submission'
         if submission_status != 0:
-            verdict = 'RUN_TIME_ERROR'
+            verdict = Verdict.RUNTIME_ERROR
         elif did_timeout:
-            verdict = 'TIME_LIMIT_EXCEEDED'
+            verdict = Verdict.TIME_LIMIT_EXCEEDED
         elif validator_status == config.RTV_WA:
-            verdict = 'WRONG_ANSWER'
+            verdict = Verdict.WRONG_ANSWER
         else:
-            verdict = 'ACCEPTED'
+            verdict = Verdict.ACCEPTED
 
     val_err = None
     if validator_error is False:

--- a/bin/interactive.py
+++ b/bin/interactive.py
@@ -111,14 +111,11 @@ def run_interactive_testcase(
 
         validator_ok = validator_process.returncode
 
-        print_verdict = None
         if validator_ok != config.RTV_AC and validator_ok != config.RTV_WA:
             config.n_error += 1
             verdict = Verdict.VALIDATOR_CRASH
         elif did_timeout:
             verdict = Verdict.TIME_LIMIT_EXCEEDED
-            if tend - tstart >= timeout:
-                print_verdict = 'TLE (aborted)'
         elif not exec_res.status:
             verdict = Verdict.RUNTIME_ERROR
         elif validator_ok == config.RTV_WA:
@@ -138,7 +135,6 @@ def run_interactive_testcase(
             validator_err.decode('utf-8', 'replace'),
             exec_res.err,
             verdict,
-            print_verdict,
         )
 
     # On Linux:
@@ -321,10 +317,8 @@ while True:
     # - more team output -> WA
     # - no more team output -> AC
 
-    print_verdict = None
     if aborted:
         verdict = Verdict.TIME_LIMIT_EXCEEDED
-        print_verdict = 'TLE (aborted)'
     elif validator_status != config.RTV_AC and validator_status != config.RTV_WA:
         config.n_error += 1
         verdict = Verdict.VALIDATOR_CRASH
@@ -364,5 +358,4 @@ while True:
         val_err,
         team_err,
         verdict,
-        print_verdict,
     )

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -459,7 +459,7 @@ class Problem:
                 subs += submissions[x]
             return subs
         if accepted_only:
-            return maybe_copy(submissions['ACCEPTED'])
+            return maybe_copy(submissions[verdicts.Verdict.ACCEPTED])
         return maybe_copy(submissions)
 
     def validators(
@@ -620,8 +620,8 @@ class Problem:
             color = Style.RESET_ALL
             char = '-'
             if testcase.name in row:
-                char = row[testcase.name][0]
-                if row[testcase.name] == 'ACCEPTED':
+                char = str(row[testcase.name])[0]
+                if row[testcase.name] == verdicts.Verdict.ACCEPTED:
                     color = Fore.GREEN
                 else:
                     color = Fore.RED
@@ -645,10 +645,10 @@ class Problem:
         for dct in verdict_table:
             failures = 0
             for t in dct:
-                if dct[t] != 'ACCEPTED':
+                if dct[t] != verdicts.Verdict.ACCEPTED:
                     failures += 1
             for t in dct:
-                if dct[t] != 'ACCEPTED':
+                if dct[t] != verdicts.Verdict.ACCEPTED:
                     scores[t] += 1.0 / failures
         scores_list = sorted(scores.values())
 
@@ -666,7 +666,8 @@ class Problem:
             # Skip all AC testcases
             if all(
                 map(
-                    lambda row: testcase.name in row and row[testcase.name] == 'ACCEPTED',
+                    lambda row: testcase.name in row
+                    and row[testcase.name] == verdicts.Verdict.ACCEPTED,
                     verdict_table,
                 )
             ):

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -617,15 +617,10 @@ class Problem:
     def _print_table(verdict_table, testcases, submission):
         # Begin by aggregating bitstrings for all testcases, and find bitstrings occurring often (>=config.TABLE_THRESHOLD).
         def single_verdict(row, testcase):
-            color = Style.RESET_ALL
-            char = '-'
             if testcase.name in row:
-                char = str(row[testcase.name])[0]
-                if row[testcase.name] == verdicts.Verdict.ACCEPTED:
-                    color = Fore.GREEN
-                else:
-                    color = Fore.RED
-            return color + char + Style.RESET_ALL
+                return verdicts.to_char(row[testcase.name])
+            else:
+                return f'{Style.DIM}-{Style.RESET_ALL}'
 
         make_verdict = lambda tc: ''.join(map(lambda row: single_verdict(row, tc), verdict_table))
         resultant_count, resultant_id = dict(), dict()
@@ -657,8 +652,16 @@ class Problem:
             'scores indicate they are critical to break some submissions. Only cases breaking at least one submission are listed.',
             file=sys.stderr,
         )
-        print(f'{Fore.RED}#{Style.RESET_ALL}: submission fails testcase', file=sys.stderr)
-        print(f'{Fore.GREEN}#{Style.RESET_ALL}: submission passes testcase\n', file=sys.stderr)
+        fail = (
+            verdicts.to_char(verdicts.Verdict.WRONG_ANSWER)
+            + verdicts.to_char(verdicts.Verdict.TIME_LIMIT_EXCEEDED)
+            + verdicts.to_char(verdicts.Verdict.RUNTIME_ERROR)
+        )
+        print(f'{fail}: submission fails testcase', file=sys.stderr)
+        print(
+            f'{verdicts.to_char(verdicts.Verdict.ACCEPTED)}: submission passes testcase\n',
+            file=sys.stderr,
+        )
 
         name_col_width = min(50, max([len(testcase.name) for testcase in testcases]))
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -147,15 +147,6 @@ class Submission(program.Program):
         # - WRONG_ANSWER / WRONG-ANSWER / NO-OUTPUT
         # - TIME_LIMIT_EXCEEDED / TIMELIMIT
         # - RUN_TIME_ERROR / RUN-ERROR
-        domjudge_verdicts = [
-            'CORRECT',
-            'WRONG-ANSWER',
-            'TIMELIMIT',
-            'RUN-ERROR',
-            'NO-OUTPUT',
-            #'CHECK-MANUALLY', TODO this is *not* supported, shouldn't pretend it is
-            'COMPILER-ERROR',
-        ]
         # Matching is case insensitive and all source files are checked.
         key = '@EXPECTED_RESULTS@: '
         if self.path.is_file():

--- a/bin/run.py
+++ b/bin/run.py
@@ -275,9 +275,7 @@ class Submission(program.Program):
             if result.verdict == Verdict.ACCEPTED and not self.problem.interactive:
                 validate.sanity_check(run.out_path, localbar, strict_whitespace=False)
 
-            with verdicts:
-                verdicts[run.name] = result.verdict
-                verdicts.duration[run.name] = result.duration
+            verdicts.set(run.name, result.verdict, result.duration)
 
             if verdict_table is not None:
                 verdict_table.finish_testcase(run.name, result.verdict)

--- a/bin/run.py
+++ b/bin/run.py
@@ -258,9 +258,7 @@ class Submission(program.Program):
             # - verbose mode
             # - table mode
             if not (config.args.verbose or config.args.table):
-                if any(
-                    verdicts.verdict[str(parent)] is not None for parent in Path(run.name).parents
-                ):
+                if any(verdicts[str(parent)] is not None for parent in Path(run.name).parents):
                     bar.count = None
                     return
 
@@ -272,7 +270,8 @@ class Submission(program.Program):
 
             if verdict_table is not None:
                 verdict_table.finish_testcase(run.name, result.verdict)
-            verdicts.set(run.name, result.verdict, duration=result.duration)
+            verdicts[run.name] = result.verdict
+            verdicts.duration[run.name] = result.duration
 
             got_expected = result.verdict in ['ACCEPTED'] + self.expected_verdicts
 
@@ -324,7 +323,7 @@ class Submission(program.Program):
             p.put(run)
         p.done()
 
-        self.verdict = verdicts.verdict['.']
+        self.verdict = verdicts['.']
         self.duration = 42
 
         # Use a bold summary line if things were printed before.
@@ -339,7 +338,9 @@ class Submission(program.Program):
             color = Fore.GREEN if self.verdict in self.expected_verdicts else Fore.RED
             boldcolor = ''
 
-        max_duration, name = max(tuple(reversed(t)) for t in verdicts.duration.items())
+        max_duration, name = max(
+            tuple(reversed(t)) for t in verdicts.duration.items() if t[1] is not None
+        )
         printed_newline = bar.finalize(
             message=f'{max_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {name}'
         )

--- a/bin/run.py
+++ b/bin/run.py
@@ -341,9 +341,21 @@ class Submission(program.Program):
 
         salient_testcase = verdicts.salient_testcase()
         salient_duration = verdicts.duration[salient_testcase]
-        printed_newline = bar.finalize(
-            message=f'{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
-        )
+        salient_color = Fore.RED if salient_duration > self.problem.settings.timeout else ''
+
+        slowest_testcase = verdicts.slowest_testcase()
+        slowest_duration = verdicts.duration[slowest_testcase]
+        slowest_color = Fore.RED if slowest_duration > self.problem.settings.timeout else ''
+        slowest_verdict = verdicts[slowest_testcase]
+
+        # NOTE: TLE and TLE (aborted) are shown the same.
+        if salient_testcase == slowest_testcase:
+            message=f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
+        else:
+            message=f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase} (slowest: {slowest_color}{slowest_duration:6.3f}s {color}{slowest_verdict}{Style.RESET_ALL} @ {slowest_testcase})'
+
+
+        printed_newline = bar.finalize(message)
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -223,10 +223,11 @@ class Submission(program.Program):
     # Run this submission on all testcases for the current problem.
     # Returns (OK verdict, printed newline)
     def run_all_testcases(
-        self, max_submission_name_len=None, verdict_table=None, *, needs_leading_newline
+        self, max_submission_name_len: int, verdict_table=None, *, needs_leading_newline
     ):
         runs = [Run(self.problem, self, testcase) for testcase in self.problem.testcases()]
-        max_item_len = max(len(run.name) for run in runs) + max_submission_name_len - len(self.name)
+        max_testcase_len = max(len(run.name) for run in runs)
+        max_item_len = max_testcase_len + max_submission_name_len - len(self.name)
         run_until = RunUntil.FIRST_ERROR
         if config.args.duration or config.args.verbose:
             run_until = RunUntil.DURATION
@@ -332,7 +333,7 @@ class Submission(program.Program):
         (salient_testcase, salient_duration) = verdicts.salient_testcase()
         salient_color = Fore.RED if salient_duration >= self.problem.settings.timeout else ''
 
-        message = f'{color}{self.verdict:<20}{salient_color}{salient_duration:6.3f}s{Style.RESET_ALL} @ {salient_testcase}'
+        message = f'{color}{self.verdict:<20}{salient_color}{salient_duration:6.3f}s{Style.RESET_ALL} @ {salient_testcase:{max_testcase_len}}'
 
         slowest_pair = verdicts.slowest_testcase()
         if slowest_pair is not None:
@@ -343,6 +344,7 @@ class Submission(program.Program):
             if salient_testcase != slowest_testcase:
                 message += f' (slowest: {color}{slowest_verdict.abbrev():>3}{slowest_color}{slowest_duration:6.3f}s{Style.RESET_ALL} @ {slowest_testcase})'
 
+        bar.item_width -= max_testcase_len
         printed_newline = bar.finalize(message=message)
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))

--- a/bin/run.py
+++ b/bin/run.py
@@ -317,7 +317,6 @@ class Submission(program.Program):
         p.done()
 
         self.verdict = verdicts['.']
-        self.duration = 42  # TODO this is messed up
 
         # Use a bold summary line if things were printed before.
         if bar.logged:

--- a/bin/run.py
+++ b/bin/run.py
@@ -332,13 +332,13 @@ class Submission(program.Program):
         (salient_testcase, salient_duration) = verdicts.salient_testcase()
         salient_color = Fore.RED if salient_duration > self.problem.settings.timeout else ''
 
-        slowest = verdicts.slowest_testcase()
-        if slowest is not None:
-            (slowest_testcase, slowest_duration) = verdicts.slowest_testcase()
+        slowest_pair = verdicts.slowest_testcase()
+        if slowest_pair is not None:
+            (slowest_testcase, slowest_duration) = slowest_pair
             slowest_color = Fore.RED if slowest_duration > self.problem.settings.timeout else ''
             slowest_verdict = verdicts[slowest_testcase]
 
-        if slowest is None or salient_testcase == slowest_testcase:
+        if slowest_pair is None or salient_testcase == slowest_testcase:
             message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
         else:
             message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase} (slowest: {slowest_color}{slowest_duration:6.3f}s {color}{slowest_verdict}{Style.RESET_ALL} @ {slowest_testcase})'

--- a/bin/run.py
+++ b/bin/run.py
@@ -254,7 +254,7 @@ class Submission(program.Program):
                 if verdicts[str(parent)] is None:
                     return False
                 if verdicts[str(parent)] == Verdict.TIME_LIMIT_EXCEEDED:
-                    children = c for c in verdicts.children[str(parent)] if verdicts.is_testcase(c)
+                    children = [c for c in verdicts.children[str(parent)] if verdicts.is_testcase(c)]
                     return any(verdicts.duration[str(c)] > self.problem.settings.timeout for c in children)
                 return True
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -343,7 +343,7 @@ class Submission(program.Program):
             color = Fore.GREEN if self.verdict in self.expected_verdicts else Fore.RED
             boldcolor = ''
 
-        (salient_testcase, saliend_duration) = verdicts.salient_testcase()
+        (salient_testcase, salient_duration) = verdicts.salient_testcase()
         salient_color = Fore.RED if salient_duration > self.problem.settings.timeout else ''
 
         (slowest_testcase, slowest_duration) = verdicts.slowest_testcase()

--- a/bin/run.py
+++ b/bin/run.py
@@ -263,10 +263,11 @@ class Submission(program.Program):
                 # Any other non-accepted verdict.
                 return True
 
-            if not (config.args.verbose or config.args.table):
-                if any(verdict_and_salient_case_known(parent) for parent in Path(run.name).parents):
-                    bar.skip()
-                    return
+            with verdicts:
+                if not (config.args.verbose or config.args.table):
+                    if any(verdict_and_salient_case_known(parent) for parent in Path(run.name).parents):
+                        bar.skip()
+                        return
 
             localbar = bar.start(run)
             result = run.run(localbar)
@@ -274,10 +275,12 @@ class Submission(program.Program):
             if result.verdict == Verdict.ACCEPTED and not self.problem.interactive:
                 validate.sanity_check(run.out_path, localbar, strict_whitespace=False)
 
+            with verdicts:
+                verdicts[run.name] = result.verdict
+                verdicts.duration[run.name] = result.duration
+
             if verdict_table is not None:
                 verdict_table.finish_testcase(run.name, result.verdict)
-            verdicts[run.name] = result.verdict
-            verdicts.duration[run.name] = result.duration
 
             got_expected = result.verdict in [Verdict.ACCEPTED] + self.expected_verdicts
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -335,14 +335,15 @@ class Submission(program.Program):
 
         message = f'{color}{self.verdict:<19}{salient_color}{salient_duration:6.3f}s{Style.RESET_ALL} @ {salient_testcase:{max_testcase_len}}'
 
-        slowest_pair = verdicts.slowest_testcase()
-        if slowest_pair is not None:
+        slowest_pair = None
+        if run_until in [RunUntil.DURATION, RunUntil.ALL]:
+            slowest_pair = verdicts.slowest_testcase()
+            assert slowest_pair is not None
             (slowest_testcase, slowest_duration) = slowest_pair
             slowest_color = Fore.RED if slowest_duration >= self.problem.settings.timeout else ''
             slowest_verdict = verdicts[slowest_testcase]
 
-            if salient_testcase != slowest_testcase:
-                message += f' (slowest: {color}{slowest_verdict.abbrev():>3}{slowest_color}{slowest_duration:6.3f}s{Style.RESET_ALL} @ {slowest_testcase})'
+            message += f' slowest: {color}{slowest_verdict.abbrev():>3}{slowest_color}{slowest_duration:6.3f}s{Style.RESET_ALL} @ {slowest_testcase}'
 
         bar.item_width -= max_testcase_len
         printed_newline = bar.finalize(message=message)

--- a/bin/run.py
+++ b/bin/run.py
@@ -228,6 +228,7 @@ class Submission(program.Program):
         runs = [Run(self.problem, self, testcase) for testcase in self.problem.testcases()]
         max_testcase_len = max(len(run.name) for run in runs)
         max_item_len = max_testcase_len + max_submission_name_len - len(self.name)
+        padding_len = max_submission_name_len - len(self.name)
         run_until = RunUntil.FIRST_ERROR
         if config.args.all == 1 or config.args.verbose:
             run_until = RunUntil.DURATION
@@ -345,7 +346,7 @@ class Submission(program.Program):
 
             message += f' slowest: {color}{slowest_verdict.abbrev():>3}{slowest_color}{slowest_duration:6.3f}s{Style.RESET_ALL} @ {slowest_testcase}'
 
-        bar.item_width -= max_testcase_len
+        bar.item_width -= max_testcase_len + 1
         printed_newline = bar.finalize(message=message)
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))

--- a/bin/run.py
+++ b/bin/run.py
@@ -153,7 +153,7 @@ class Submission(program.Program):
             'TIMELIMIT',
             'RUN-ERROR',
             'NO-OUTPUT',
-            'CHECK-MANUALLY',
+            #'CHECK-MANUALLY', TODO this is *not* supported, shouldn't pretend it is
             'COMPILER-ERROR',
         ]
         # Matching is case insensitive and all source files are checked.

--- a/bin/run.py
+++ b/bin/run.py
@@ -330,24 +330,24 @@ class Submission(program.Program):
             boldcolor = ''
 
         (salient_testcase, salient_duration) = verdicts.salient_testcase()
-        salient_color = Fore.RED if salient_duration > self.problem.settings.timeout else ''
+        salient_color = Fore.RED if salient_duration >= self.problem.settings.timeout else ''
+
+        message = f'{color}{self.verdict:<20}{salient_color}{salient_duration:6.3f}s{Style.RESET_ALL} @ {salient_testcase}'
 
         slowest_pair = verdicts.slowest_testcase()
         if slowest_pair is not None:
             (slowest_testcase, slowest_duration) = slowest_pair
-            slowest_color = Fore.RED if slowest_duration > self.problem.settings.timeout else ''
+            slowest_color = Fore.RED if slowest_duration >= self.problem.settings.timeout else ''
             slowest_verdict = verdicts[slowest_testcase]
 
-        if slowest_pair is None or salient_testcase == slowest_testcase:
-            message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
-        else:
-            message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase} (slowest: {slowest_color}{slowest_duration:6.3f}s {color}{slowest_verdict}{Style.RESET_ALL} @ {slowest_testcase})'
+            if salient_testcase != slowest_testcase:
+                message += f' (slowest: {color}{slowest_verdict.abbrev():>3}{slowest_color}{slowest_duration:6.3f}s{Style.RESET_ALL} @ {slowest_testcase})'
 
         printed_newline = bar.finalize(message=message)
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))
 
-        return (self.verdict in self.expected_verdicts, printed_newline)
+        return self.verdict in self.expected_verdicts, printed_newline
 
     def test(self):
         print(ProgressBar.action('Running', str(self.name)), file=sys.stderr)

--- a/bin/run.py
+++ b/bin/run.py
@@ -255,8 +255,10 @@ class Submission(program.Program):
                     return False
                 if verdicts[str(parent)] == Verdict.TIME_LIMIT_EXCEEDED:
                     for c in children:
-                        if !verdicts.is_testcase(c): continue
-                        if verdicts.duration[str(c)] is None: continue
+                        if not verdicts.is_testcase(c):
+                            continue
+                        if verdicts.duration[str(c)] is None:
+                            continue
                         if verdicts.duration[str(c)] >= self.problem.settings.timeout:
                             return True
                     return False
@@ -265,7 +267,9 @@ class Submission(program.Program):
 
             with verdicts:
                 if not (config.args.verbose or config.args.table):
-                    if any(verdict_and_salient_case_known(parent) for parent in Path(run.name).parents):
+                    if any(
+                        verdict_and_salient_case_known(parent) for parent in Path(run.name).parents
+                    ):
                         bar.skip()
                         return
 
@@ -350,10 +354,9 @@ class Submission(program.Program):
 
         # NOTE: TLE and TLE (aborted) are shown the same.
         if salient_testcase == slowest_testcase:
-            message=f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
+            message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
         else:
-            message=f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase} (slowest: {slowest_color}{slowest_duration:6.3f}s {color}{slowest_verdict}{Style.RESET_ALL} @ {slowest_testcase})'
-
+            message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase} (slowest: {slowest_color}{slowest_duration:6.3f}s {color}{slowest_verdict}{Style.RESET_ALL} @ {slowest_testcase})'
 
         printed_newline = bar.finalize(message)
         if config.args.tree:

--- a/bin/run.py
+++ b/bin/run.py
@@ -244,8 +244,8 @@ class Submission(program.Program):
                 needs_leading_newline=needs_leading_newline,
             )
 
-        def process_run(run, p):
-            # Lazy judging: stop as soon as parental verdicts are known, except if in
+        def process_run(run):
+            # Lazy judging: stop as soon some parental verdict is known, except if in
             # - verbose mode
             # - table mode
             if not (config.args.verbose or config.args.table):
@@ -286,7 +286,7 @@ class Submission(program.Program):
             # Add data from feedbackdir.
             for f in run.feedbackdir.iterdir():
                 if not f.is_file():
-                    localbar.warn(f'Validator wrote to {f} but it\'s not a file.')
+                    localbar.warn(f"Validator wrote to {f} but it's not a file.")
                     continue
                 try:
                     t = f.read_text()
@@ -304,12 +304,7 @@ class Submission(program.Program):
 
             localbar.done(got_expected, f'{result.duration:6.3f}s {result.print_verdict()}', data)
 
-            # - for TLE, the run was aborted because the global timeout expired
-            # TODO: What does this mean?
-            if result.verdict == Verdict.TIME_LIMIT_EXCEEDED and not result.timeout_expired:
-                return
-
-        p = parallel.new_queue(lambda run: process_run(run, p), pin=True)
+        p = parallel.new_queue(process_run, pin=True)
         for run in runs:
             p.put(run)
         p.done()

--- a/bin/run.py
+++ b/bin/run.py
@@ -242,14 +242,14 @@ class Submission(program.Program):
 
         if verdict_table is not None:
             bar = verdict_table.ProgressBar(
-                'Running ' + self.name,
+                self.name,
                 count=len(runs),
                 max_len=max_item_len,
                 needs_leading_newline=needs_leading_newline,
             )
         else:
             bar = ProgressBar(
-                'Running ' + self.name,
+                self.name,
                 count=len(runs),
                 max_len=max_item_len,
                 needs_leading_newline=needs_leading_newline,
@@ -333,7 +333,7 @@ class Submission(program.Program):
         (salient_testcase, salient_duration) = verdicts.salient_testcase()
         salient_color = Fore.RED if salient_duration >= self.problem.settings.timeout else ''
 
-        message = f'{color}{self.verdict:<20}{salient_color}{salient_duration:6.3f}s{Style.RESET_ALL} @ {salient_testcase:{max_testcase_len}}'
+        message = f'{color}{self.verdict:<19}{salient_color}{salient_duration:6.3f}s{Style.RESET_ALL} @ {salient_testcase:{max_testcase_len}}'
 
         slowest_pair = verdicts.slowest_testcase()
         if slowest_pair is not None:

--- a/bin/run.py
+++ b/bin/run.py
@@ -248,8 +248,18 @@ class Submission(program.Program):
             # Lazy judging: stop as soon some parental verdict is known, except if in
             # - verbose mode
             # - table mode
+            #
+            # When the parent verdict is TLE, do continue when the timeout has not been reached.
+            def verdict_and_salient_case_known(parent):
+                if verdicts[str(parent)] is None:
+                    return False
+                if verdicts[str(parent)] == Verdict.TIME_LIMIT_EXCEEDED:
+                    children = c for c in verdicts.children[str(parent)] if verdicts.is_testcase(c)
+                    return any(verdicts.duration[str(c)] > self.problem.settings.timeout for c in children)
+                return True
+
             if not (config.args.verbose or config.args.table):
-                if any(verdicts[str(parent)] is not None for parent in Path(run.name).parents):
+                if any(verdict_and_salient_case_known(parent) for parent in Path(run.name).parents):
                     bar.skip()
                     return
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -229,9 +229,9 @@ class Submission(program.Program):
         max_testcase_len = max(len(run.name) for run in runs)
         max_item_len = max_testcase_len + max_submission_name_len - len(self.name)
         run_until = RunUntil.FIRST_ERROR
-        if config.args.duration or config.args.verbose:
+        if config.args.all == 1 or config.args.verbose:
             run_until = RunUntil.DURATION
-        if config.args.all:
+        if config.args.all >= 2:
             run_until = RunUntil.ALL
 
         verdicts = Verdicts(

--- a/bin/run.py
+++ b/bin/run.py
@@ -368,7 +368,7 @@ class Submission(program.Program):
             message=f'{max_duration:6.3f}s {color}{self.print_verdict:<20}{Style.RESET_ALL} @ {verdict_run.testcase.name}'
         )
         if config.args.tree:
-            print(thoreverdicts.as_tree())
+            print(thoreverdicts.as_tree(max_depth=config.args.depth))
 
         return (self.verdict in self.expected_verdicts, printed_newline)
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -330,10 +330,10 @@ class Submission(program.Program):
             color = Fore.GREEN if self.verdict in self.expected_verdicts else Fore.RED
             boldcolor = ''
 
-        max_duration = max(d for d in verdicts.duration.values() if d is not None)
         salient_testcase = verdicts.salient_testcase()
+        salient_duration = verdicts.duration[salient_testcase]
         printed_newline = bar.finalize(
-            message=f'{max_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
+            message=f'{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
         )
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))

--- a/bin/run.py
+++ b/bin/run.py
@@ -343,12 +343,10 @@ class Submission(program.Program):
             color = Fore.GREEN if self.verdict in self.expected_verdicts else Fore.RED
             boldcolor = ''
 
-        salient_testcase = verdicts.salient_testcase()
-        salient_duration = verdicts.duration[salient_testcase]
+        (salient_testcase, saliend_duration) = verdicts.salient_testcase()
         salient_color = Fore.RED if salient_duration > self.problem.settings.timeout else ''
 
-        slowest_testcase = verdicts.slowest_testcase()
-        slowest_duration = verdicts.duration[slowest_testcase]
+        (slowest_testcase, slowest_duration) = verdicts.slowest_testcase()
         slowest_color = Fore.RED if slowest_duration > self.problem.settings.timeout else ''
         slowest_verdict = verdicts[slowest_testcase]
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -254,7 +254,7 @@ class Submission(program.Program):
                 if verdicts[str(parent)] is None:
                     return False
                 if verdicts[str(parent)] == Verdict.TIME_LIMIT_EXCEEDED:
-                    for c in children:
+                    for c in verdicts.children[str(parent)]:
                         if not verdicts.is_testcase(c):
                             continue
                         if verdicts.duration[str(c)] is None:

--- a/bin/run.py
+++ b/bin/run.py
@@ -367,7 +367,8 @@ class Submission(program.Program):
         printed_newline = bar.finalize(
             message=f'{max_duration:6.3f}s {color}{self.print_verdict:<20}{Style.RESET_ALL} @ {verdict_run.testcase.name}'
         )
-        print(thoreverdicts.as_tree())
+        if config.args.tree:
+            print(thoreverdicts.as_tree())
 
         return (self.verdict in self.expected_verdicts, printed_newline)
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -40,7 +40,6 @@ class Run:
             result = interactive.run_interactive_testcase(
                 self, interaction=interaction, submission_args=submission_args
             )
-            # TODO : this is messed up wrt result.verdict being str
         else:
             result = self.submission.run(self.testcase.in_path, self.out_path)
             if result.duration > self.problem.settings.timelimit:

--- a/bin/run.py
+++ b/bin/run.py
@@ -250,7 +250,7 @@ class Submission(program.Program):
             # - table mode
             if not (config.args.verbose or config.args.table):
                 if any(verdicts[str(parent)] is not None for parent in Path(run.name).parents):
-                    bar.count = None
+                    bar.skip()
                     return
 
             localbar = bar.start(run)

--- a/bin/run.py
+++ b/bin/run.py
@@ -254,8 +254,12 @@ class Submission(program.Program):
                 if verdicts[str(parent)] is None:
                     return False
                 if verdicts[str(parent)] == Verdict.TIME_LIMIT_EXCEEDED:
-                    children = [c for c in verdicts.children[str(parent)] if verdicts.is_testcase(c)]
-                    return any(verdicts.duration[str(c)] > self.problem.settings.timeout for c in children)
+                    children = [
+                        c for c in verdicts.children[str(parent)] if verdicts.is_testcase(c)
+                    ]
+                    return any(
+                        verdicts.duration[str(c)] > self.problem.settings.timeout for c in children
+                    )
                 return True
 
             if not (config.args.verbose or config.args.table):

--- a/bin/run.py
+++ b/bin/run.py
@@ -254,12 +254,13 @@ class Submission(program.Program):
                 if verdicts[str(parent)] is None:
                     return False
                 if verdicts[str(parent)] == Verdict.TIME_LIMIT_EXCEEDED:
-                    children = [
-                        c for c in verdicts.children[str(parent)] if verdicts.is_testcase(c)
-                    ]
-                    return any(
-                        verdicts.duration[str(c)] > self.problem.settings.timeout for c in children
-                    )
+                    for c in children:
+                        if !verdicts.is_testcase(c): continue
+                        if verdicts.duration[str(c)] is None: continue
+                        if verdicts.duration[str(c)] >= self.problem.settings.timeout:
+                            return True
+                    return False
+                # Any other non-accepted verdict.
                 return True
 
             if not (config.args.verbose or config.args.table):

--- a/bin/run.py
+++ b/bin/run.py
@@ -358,7 +358,7 @@ class Submission(program.Program):
         else:
             message = f'{salient_color}{salient_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase} (slowest: {slowest_color}{slowest_duration:6.3f}s {color}{slowest_verdict}{Style.RESET_ALL} @ {slowest_testcase})'
 
-        printed_newline = bar.finalize(message)
+        printed_newline = bar.finalize(message=message)
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -236,8 +236,8 @@ class Submission(program.Program):
 
         verdicts = Verdicts(
             (str(t.name) for t in self.problem.testcases()),
-            run_until,
             self.problem.settings.timeout,
+            run_until,
         )
 
         if verdict_table is not None:

--- a/bin/run.py
+++ b/bin/run.py
@@ -340,11 +340,10 @@ class Submission(program.Program):
             color = Fore.GREEN if self.verdict in self.expected_verdicts else Fore.RED
             boldcolor = ''
 
-        max_duration, name = max(
-            tuple(reversed(t)) for t in verdicts.duration.items() if t[1] is not None
-        )
+        max_duration = max(d for d in verdicts.duration.values() if d is not None)
+        salient_testcase = verdicts.salient_testcase()
         printed_newline = bar.finalize(
-            message=f'{max_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {name}'
+            message=f'{max_duration:6.3f}s {color}{self.verdict:<20}{Style.RESET_ALL} @ {salient_testcase}'
         )
         if config.args.tree:
             print(verdicts.as_tree(max_depth=config.args.depth))

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -599,12 +599,8 @@ Run this from one of:
     runparser.add_argument(
         '--table', action='store_true', help='Print a submissions x testcases table for analysis.'
     )
-    runparser.add_argument(
-        '--tree', action='store_true', help='Show a tree of verdicts.'
-    )
-    runparser.add_argument(
-        '--depth', type=int, help='Depth of verdict tree.'
-    )
+    runparser.add_argument('--tree', action='store_true', help='Show a tree of verdicts.')
+    runparser.add_argument('--depth', type=int, help='Depth of verdict tree.')
     runparser.add_argument(
         '--overview', '-o', action='store_true', help='Print a live overview for the judgings.'
     )

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -600,6 +600,12 @@ Run this from one of:
         '--table', action='store_true', help='Print a submissions x testcases table for analysis.'
     )
     runparser.add_argument(
+        '--tree', action='store_true', help='Show a tree of verdicts.'
+    )
+    runparser.add_argument(
+        '--depth', type=int, help='Depth of verdict tree.'
+    )
+    runparser.add_argument(
         '--overview', '-o', action='store_true', help='Print a live overview for the judgings.'
     )
     runparser.add_argument(

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -606,11 +606,13 @@ Run this from one of:
     runparser.add_argument(
         '--table', action='store_true', help='Print a submissions x testcases table for analysis.'
     )
-    runparser.add_argument('--tree', action='store_true', help='Show a tree of verdicts.')
-    runparser.add_argument('--depth', type=int, help='Depth of verdict tree.')
-    runparser.add_argument(
+    runparser_display = runparser.add_mutually_exclusive_group()
+    runparser_display.add_argument(
         '--overview', '-o', action='store_true', help='Print a live overview for the judgings.'
     )
+    runparser_display.add_argument('--tree', action='store_true', help='Show a tree of verdicts.')
+
+    runparser.add_argument('--depth', type=int, help='Depth of verdict tree.')
     runparser.add_argument(
         '--timeout',
         type=int,

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -591,6 +591,18 @@ Run this from one of:
         help='Do not run `generate` before running submissions.',
     )
     runparser.add_argument(
+        '--all',
+        '-a',
+        action='store_true',
+        help='Run all testcases',
+    )
+    runparser.add_argument(
+        '--duration',
+        '-d',
+        action='store_true',
+        help='Determine slowest testcase',
+    )
+    runparser.add_argument(
         '--default-solution',
         '-s',
         type=Path,

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -593,14 +593,9 @@ Run this from one of:
     runparser.add_argument(
         '--all',
         '-a',
-        action='store_true',
-        help='Run all testcases',
-    )
-    runparser.add_argument(
-        '--duration',
-        '-d',
-        action='store_true',
-        help='Determine slowest testcase',
+        action='count',
+        default=0,
+        help='Run all testcases. Use twice to continue even after timeouts.',
     )
     runparser.add_argument(
         '--default-solution',

--- a/bin/util.py
+++ b/bin/util.py
@@ -874,7 +874,6 @@ class ExecResult:
         err,
         out,
         verdict=None,
-        print_verdict=None,
     ):
         self.returncode = returncode
         assert type(status) is ExecStatus
@@ -884,12 +883,6 @@ class ExecResult:
         self.err = err
         self.out = out
         self.verdict = verdict
-        self.print_verdict_ = print_verdict
-
-    def print_verdict(self):
-        if self.print_verdict_:
-            return self.print_verdict_
-        return self.verdict
 
 
 def limit_setter(command, timeout, memory_limit, group=None, cores=False):

--- a/bin/util.py
+++ b/bin/util.py
@@ -402,6 +402,11 @@ class ProgressBar:
             if not resume:
                 self._release_item()
 
+    # Skip an item.
+    def skip(self):
+        with self:
+            self.i += 1
+
     # Log a final line if it's an error or if nothing was printed yet and we're in verbose mode.
     def done(self, success=True, message='', data=''):
         with self:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -152,7 +152,7 @@ class Verdicts:
         # testgroup -> testcase | None
         self.first_error: dict[str, str | None] = {node: None for node in testgroups}
         # testgroup -> testcase iterator
-        self._unknowns = {node: self.unknowns_iterator(node) for node in testgroups}
+        self._unknowns = {node: self._unknowns_iterator(node) for node in testgroups}
         # testgroup -> testcase | None
         self.first_unknown: dict[str, str | None] = {
             node: next(self._unknowns[node]) for node in testgroups
@@ -165,13 +165,12 @@ class Verdicts:
     def __exit__(self, *args):
         self.lock.__exit__(*args)
 
-    def unknowns_iterator(self, node):
+    def _unknowns_iterator(self, node):
         """Yield the node's (yet) unknown children in lexicographic order."""
-        with self:
-            for child in self.children[node]:
-                if self._verdict[child] is not None:
-                    continue
-                yield child
+        for child in self.children[node]:
+            if self._verdict[child] is not None:
+                continue
+            yield child
 
     def is_testgroup(self, node) -> bool:
         """Is the given testnode name a testgroup (rather than a testcase)?

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -16,6 +16,7 @@ class Verdict(Enum):
     TIME_LIMIT_EXCEEDED = 3
     RUNTIME_ERROR = 4
     VALIDATOR_CRASH = 5
+    COMPILER_ERROR = 5
 
     def __str__(self):
         return {
@@ -23,6 +24,7 @@ class Verdict(Enum):
             Verdict.WRONG_ANSWER: 'WRONG ANSWER',
             Verdict.TIME_LIMIT_EXCEEDED: 'TIME LIMIT EXCEEDED',
             Verdict.RUNTIME_ERROR: 'RUNTIME ERROR',
+            Verdict.COMPILER_ERROR: 'COMPILER ERROR',
         }[self]
 
 
@@ -58,10 +60,13 @@ def from_string(s: str) -> Verdict:
             return Verdict.RUNTIME_ERROR
         case 'NO-OUTPUT':
             return Verdict.WRONG_ANSWER
-        case 'CHECK-MANUALLY' | 'COMPILER-ERROR':
+        case 'COMPILER-ERROR':
+            return Verdict.COMPILER_ERROR
+        case 'CHECK-MANUALLY':
             raise NotImplementedError
         case _:
-            raise ValueError(f"Unknown verdict string {s}")
+            return None
+            # raise ValueError(f"Unknown verdict string {s}")
 
 
 class Verdicts:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -201,7 +201,8 @@ class Verdicts:
 
     def salient_testcase(self) -> str:
         """The testcase most salient to the root verdict.
-        If self['.'] is Verdict.ACCEPTED or Verdict.TIME_LIMIT_EXCEEDED, then this is the slowest testcase.
+        If self['.'] is Verdict.ACCEPTED, then this is the slowest testcase.
+        If self['.'] is Verdict.TIME_LIMIT_EXCEEDED, then this is the slowest testcase with TLE verdict.
         Otherwise it is the lexicographically first testcase that was rejected."""
         with self:
             match self['.']:
@@ -209,15 +210,19 @@ class Verdicts:
                     raise ValueError("Salient testcase called before submission verdict determined")
                 # 'ACCEPTED | TIME_LIMIT_EXCEEDED' is only for python >=3.10.
                 case Verdict.ACCEPTED:
-                    return max((v, k) for k, v in self.duration.items())[1]
+                    return max((v, tc) for tc, v in self.duration.items())[1]
                 case Verdict.TIME_LIMIT_EXCEEDED:
-                    return max((v, k) for k, v in self.duration.items())[1]
+                    return max(
+                        (v, tc)
+                        for tc, v in self.duration.items()
+                        if self._verdict[k] == Verdict.TIME_LIMIT_EXCEEDED
+                    )[1]
                 case _:
                     return min(
-                        (k, v)
-                        for k, v in sorted(self._verdict.items())
+                        tc
+                        for tc, v in self._verdict.items()
                         if self.is_testcase(k) and v is not Verdict.ACCEPTED
-                    )[0]
+                    )
 
     def aggregate(self, testgroup: str) -> Verdict:
         """The aggregate verdict at the given testgroup.

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -14,14 +14,15 @@ class Verdict(Enum):
     ACCEPTED = 1
     WRONG_ANSWER = 2
     TIME_LIMIT_EXCEEDED = 3
-    RUN_TIME_ERROR = 4
+    RUNTIME_ERROR = 4
+    VALIDATOR_CRASH = 5
 
     def __str__(self):
         return {
             Verdict.ACCEPTED: 'ACCEPTED',
             Verdict.WRONG_ANSWER: 'WRONG ANSWER',
             Verdict.TIME_LIMIT_EXCEEDED: 'TIME LIMIT EXCEEDED',
-            Verdict.RUN_TIME_ERROR: 'RUNTIME ERROR',
+            Verdict.RUNTIME_ERROR: 'RUNTIME ERROR',
         }[self]
 
 
@@ -30,7 +31,7 @@ def to_string(v: Verdict | None):
         Verdict.ACCEPTED: f'{Fore.GREEN}ACCEPTED{Style.RESET_ALL}',
         Verdict.WRONG_ANSWER: f'{Fore.RED}WRONG ANSWER{Style.RESET_ALL}',
         Verdict.TIME_LIMIT_EXCEEDED: f'{Fore.MAGENTA}TIME LIMIT EXCEEDED{Style.RESET_ALL}',
-        Verdict.RUN_TIME_ERROR: f'{Fore.YELLOW}RUNTIME ERROR{Style.RESET_ALL}',
+        Verdict.RUNTIME_ERROR: f'{Fore.YELLOW}RUNTIME ERROR{Style.RESET_ALL}',
         None: f'{Fore.BLUE}?{Style.RESET_ALL}',
     }[v]
 
@@ -40,21 +41,25 @@ def to_char(v: Verdict | None):
         Verdict.ACCEPTED: f'{Fore.GREEN}A{Style.RESET_ALL}',
         Verdict.WRONG_ANSWER: f'{Fore.RED}W{Style.RESET_ALL}',
         Verdict.TIME_LIMIT_EXCEEDED: f'{Fore.MAGENTA}T{Style.RESET_ALL}',
-        Verdict.RUN_TIME_ERROR: f'{Fore.YELLOW}R{Style.RESET_ALL}',
+        Verdict.RUNTIME_ERROR: f'{Fore.YELLOW}R{Style.RESET_ALL}',
         None: f'{Fore.BLUE}?{Style.RESET_ALL}',
     }[v]
 
 
 def from_string(s: str) -> Verdict:
     match s:
-        case 'ACCEPTED' | 'AC':
+        case 'CORRECT' | 'ACCEPTED' | 'AC':
             return Verdict.ACCEPTED
-        case 'WRONG_ANSWER' | 'WA':
+        case 'WRONG-ANSWER' | 'WRONG_ANSWER' | 'WA':
             return Verdict.WRONG_ANSWER
-        case 'TIME_LIMIT_EXCEEDED' | 'TLE':
+        case 'TIMELIMIT' | 'TIME_LIMIT_EXCEEDED' | 'TLE':
             return Verdict.TIME_LIMIT_EXCEEDED
-        case 'RUN_TIME_ERROR' | 'RTE':
-            return Verdict.RUN_TIME_ERROR
+        case 'RUN-ERROR' | 'RUN_TIME_ERROR' | 'RUNTIME_ERROR' | 'RTE':
+            return Verdict.RUNTIME_ERROR
+        case 'NO-OUTPUT':
+            return Verdict.WRONG_ANSWER
+        case 'CHECK-MANUALLY' | 'COMPILER-ERROR':
+            raise NotImplementedError
         case _:
             raise ValueError(f"Unknown verdict string {s}")
 
@@ -221,7 +226,7 @@ class VerdictTable:
         'ACCEPTED': Fore.GREEN,
         'WRONG_ANSWER': Fore.RED,
         'TIME_LIMIT_EXCEEDED': Fore.MAGENTA,
-        'RUN_TIME_ERROR': Fore.YELLOW,
+        'RUNTIME_ERROR': Fore.YELLOW,
     }
 
     def __init__(

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -26,6 +26,7 @@ def to_string(v: Verdict | None):
         None: f'{Fore.BLUE}?{Style.RESET_ALL}',
     }[v]
 
+
 def to_char(v: Verdict | None):
     return {
         Verdict.ACCEPTED: f'{Fore.GREEN}A{Style.RESET_ALL}',
@@ -34,7 +35,6 @@ def to_char(v: Verdict | None):
         Verdict.RUN_TIME_ERROR: f'{Fore.YELLOW}R{Style.RESET_ALL}',
         None: f'{Fore.BLUE}?{Style.RESET_ALL}',
     }[v]
-
 
 
 def from_string(s: str) -> Verdict:
@@ -108,8 +108,8 @@ class Verdicts:
         }
 
     def is_testgroup(self, node) -> bool:
-        """ Is the given testnode name a testgroup (rather than a testcase)?
-            This assumes nonempty testgroups.
+        """Is the given testnode name a testgroup (rather than a testcase)?
+        This assumes nonempty testgroups.
         """
         return node in self.children
 
@@ -183,15 +183,12 @@ class Verdicts:
                 updated_node = self._set_verdict_for_node(parent, self.aggregate(parent))
         return updated_node
 
-    def as_tree(self, show_root=True, max_depth=None) -> str:
+    def as_tree(self, max_depth=None) -> str:
         result = []
         stack = [('.', '', '', True)]
-        root = True
         while stack:
             node, indent, prefix, last = stack.pop()
-            if not root or show_root:
-                result.append(f"{indent}{prefix}{node.split('/')[-1]}: {to_string(self.verdict[node])}")
-            root = False
+            result.append(f"{indent}{prefix}{node.split('/')[-1]}: {to_string(self.verdict[node])}")
             children = sorted(self.children[node], reverse=True)
             pipe = ' ' if last else '│'
             first = True

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -146,7 +146,12 @@ class Verdicts:
     - duration[testcase]: the duration of the testcase
     """
 
-    def __init__(self, testcase_list: list[str], run_until: RunUntil, timeout: float):
+    def __init__(
+        self,
+        testcase_list: list[str],
+        run_until: RunUntil = RunUntil.FIRST_ERROR,
+        timeout: float = 1,
+    ):
         testcases = set(testcase_list)
         testgroups: set[str] = set(str(path) for tc in testcases for path in Path(tc).parents)
 
@@ -190,7 +195,7 @@ class Verdicts:
         """
         return node not in self.children
 
-    def set(self, testcase, verdict: str | Verdict, duration: float | None):
+    def set(self, testcase, verdict: str | Verdict, duration: float):
         """Set the verdict and duration of the given testcase (implying possibly others)
 
         verdict can be given as a Verdict or as a string using either long or

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -207,7 +207,7 @@ class Verdicts:
             if testcases:
                 edge = '└' if first else '├'
                 result.append(indent + pipe + ' ' + edge + '─' + ''.join(reversed(testcases)))
-        return '\n'.join(result[int(not show_root):])
+        return '\n'.join(result[int(not show_root) :])
 
 
 class VerdictTable:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -178,18 +178,21 @@ class Verdicts:
         return self._verdict[testnode]
 
     def salient_testcase(self) -> str:
-        """The testcase most salient to the root verdict. If
-        self['.'] == Verdict.ACCEPTED then this is the slowest testcase.
+        """The testcase most salient to the root verdict.
+        If self['.'] is Verdict.ACCEPTED or Verdict.TIME_LIMIT_EXCEEDED, then this is the slowest testcase.
         Otherwise it is the lexicographically first testcase that was rejected."""
         match self['.']:
             case None:
                 raise ValueError("Salient testcase called before submission verdict determined")
+            # 'ACCEPTED | TIME_LIMIT_EXCEEDED' is only for python >=3.10.
             case Verdict.ACCEPTED:
+                return max((v, k) for k, v in self.duration.items())[1]
+            case Verdict.TIME_LIMIT_EXCEEDED:
                 return max((v, k) for k, v in self.duration.items())[1]
             case _:
                 return min(
                     (k, v)
-                    for k, v in self._verdict.items()
+                    for k, v in sorted(self._verdict.items())
                     if self.is_testcase(k) and v is not Verdict.ACCEPTED
                 )[0]
 

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -143,7 +143,7 @@ class Verdicts:
         """
         return node not in self.children
 
-    def __setitem__(self, testcase, verdict: str | Verdict, duration=None):
+    def __setitem__(self, testcase, verdict: str | Verdict):
         """Set the verdict of the given testcase (implying possibly others)
 
         verdict can be given as a Verdict or as a string using either long or
@@ -152,8 +152,6 @@ class Verdicts:
 
         if isinstance(verdict, str):
             verdict = from_string(verdict)
-        if verdict == Verdict.ACCEPTED and duration is not None:
-            self.duration[testcase] = duration
         self._set_verdict_for_node(testcase, verdict)
 
     def __getitem__(self, testnode) -> Verdict | None:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -99,7 +99,7 @@ class Verdicts:
 
     Testcases and testgroups are identified by strings.  In particular,
     * the testcase whose input file is 'a/b/1.in' is called 'a/b/1'
-    * the three topmost testgroups are 'sample', 'secret'
+    * the two topmost testgroups are 'sample', 'secret'
     * the root is called '.'
 
     Initialised with all testcases. Individual verdicts are registered

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -221,16 +221,16 @@ class Verdicts:
     def slowest_testcase(self) -> (str, float):
         """The slowest testcase, if all cases were run or a timeout occurred."""
         with self:
-            (tc, d) = max(
+            tc, d = max(
                 ((tc, d) for tc, d in self.duration.items() if d is not None), key=lambda x: x[1]
             )
-            if d >= self.timeout:
-                return (tc, d)
 
-            if None in self.duration.values():
+            # If not all test cases were run and the max duration is less than the timeout,
+            # we cannot claim that we know the slowest test case.
+            if None in self.duration.values() and d < self.timeout:
                 return None
 
-            return (tc, d)
+            return tc, d
 
     def aggregate(self, testgroup: str) -> Verdict:
         """The aggregate verdict at the given testgroup.

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -106,13 +106,6 @@ class Verdicts:
         in lexicographic order
     """
 
-    def unknowns_iterator(self, node):
-        """Yield the node's (yet) unknown children in lexicographic order."""
-        for child in sorted(self.children[node]):
-            if self._verdict[child] is not None:
-                continue
-            yield child
-
     def __init__(self, testcase_list: list[str]):
         testcases = set(testcase_list)
         testgroups: set[str] = set(str(path) for tc in testcases for path in Path(tc).parents)
@@ -130,6 +123,13 @@ class Verdicts:
         self.first_unknown: dict[str, str | None] = {
             node: next(self._unknowns[node]) for node in testgroups
         }
+
+    def unknowns_iterator(self, node):
+        """Yield the node's (yet) unknown children in lexicographic order."""
+        for child in sorted(self.children[node]):
+            if self._verdict[child] is not None:
+                continue
+            yield child
 
     def is_testgroup(self, node) -> bool:
         """Is the given testnode name a testgroup (rather than a testcase)?
@@ -158,8 +158,8 @@ class Verdicts:
         return self._verdict[testnode]
 
     def salient_testcase(self) -> str:
-        """The testcase most salient to the root verdict. If 
-        self['.'] == Verdict.ACCEPTED then this is the slowest testcase. 
+        """The testcase most salient to the root verdict. If
+        self['.'] == Verdict.ACCEPTED then this is the slowest testcase.
         Otherwise it is the lexicographically first testcase that was rejected."""
         match self['.']:
             case None:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -146,8 +146,6 @@ class Verdicts:
 
         # testgroup -> testcase | None
         self.first_error: dict[str, str | None] = {node: None for node in testgroups}
-        # testgroup -> int | None, counts both testgroups and testcases.
-        self.num_unknowns: dict[str, int] = {node: len(self.children[node]) for node in testgroups}
         # testgroup -> testcase iterator
         self._unknowns = {node: self.unknowns_iterator(node) for node in testgroups}
         # testgroup -> testcase | None
@@ -261,12 +259,13 @@ class Verdicts:
             first_unknown = self.first_unknown[parent]
             first_error = self.first_error[parent]
 
-            self.num_unknowns[parent] -= 1
             # possibly update first_unknown at parent
             if testnode == first_unknown:
-                first_unknown = self.first_unknown[parent] = (
-                    None if self.num_unknowns[parent] == 0 else next(self._unknowns[parent])
-                )
+                try:
+                    first_unknown = next(self._unknowns[parent])
+                except StopIteration:
+                    first_unknown = None
+                self.first_unknown[parent] = first_unknown
 
             # possibly update first_error at parent
             if verdict != Verdict.ACCEPTED and (first_error is None or first_error > testnode):

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -16,6 +16,14 @@ class Verdict(Enum):
     TIME_LIMIT_EXCEEDED = 3
     RUN_TIME_ERROR = 4
 
+    def __str__(self):
+        return {
+            Verdict.ACCEPTED: 'ACCEPTED',
+            Verdict.WRONG_ANSWER: 'WRONG ANSWER',
+            Verdict.TIME_LIMIT_EXCEEDED: 'TIME LIMIT EXCEEDED',
+            Verdict.RUN_TIME_ERROR: 'RUNTIME ERROR',
+        }[self]
+
 
 def to_string(v: Verdict | None):
     return {
@@ -94,6 +102,7 @@ class Verdicts:
         testcases = set(testcase_list)
         testgroups: set[str] = set(str(path) for tc in testcases for path in Path(tc).parents)
         self.verdict: dict[str, Verdict | None] = {g: None for g in testcases | testgroups}
+        self.duration: dict[str, int | None] = {g: None for g in testcases}
 
         self.children: dict[str, set[str]] = {node: set() for node in testgroups}
         for node in testcases | testgroups:
@@ -113,7 +122,7 @@ class Verdicts:
         """
         return node in self.children
 
-    def set(self, testcase, verdict: str | Verdict) -> str:
+    def set(self, testcase, verdict: str | Verdict, duration=None) -> str:
         """Set the verdict of the given testcase (implying possibly others)
 
         verdict can be given as a Verdict or as a string using either long or
@@ -126,6 +135,8 @@ class Verdicts:
 
         if isinstance(verdict, str):
             verdict = from_string(verdict)
+        if verdict == Verdict.ACCEPTED and duration is not None:
+            self.duration[testcase] = duration
         return self._set_verdict_for_node(testcase, verdict)
 
     def aggregate(self, testgroup: str) -> Verdict:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -458,8 +458,3 @@ class TableProgressBar(ProgressBar):
             res = super().finalize(print_done=print_done, message=message)
             self.table._clear(force=True)
             return res
-
-
-# if __name__ == "__main__":
-#    import doctest
-#    doctest.testmod()

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -127,7 +127,7 @@ class Verdicts:
     available (and returns the topmost inferred testgroup).
     Verdicts (registered and inferred) are accessed with __getitem__
 
-    >>> V = Verdicts(["a/b/1", "a/b/2", "a/c/1", "a/d/1", "b/3"])
+    >>> V = Verdicts(["a/b/1", "a/b/2", "a/c/1", "a/d/1", "b/3"], timeout=1.0)
     >>> V.set('a/b/1', 'ACCEPTED', 1.0)
     >>> V.set('a/b/2', 'AC', 1.0) # returns 'a/b' because that verdict will be set as well
     >>> print(V['a/b'], V['.'])
@@ -149,8 +149,8 @@ class Verdicts:
     def __init__(
         self,
         testcase_list: list[str],
-        run_until: RunUntil = RunUntil.FIRST_ERROR,
         timeout: float = 1,
+        run_until: RunUntil = RunUntil.FIRST_ERROR,
     ):
         testcases = set(testcase_list)
         testgroups: set[str] = set(str(path) for tc in testcases for path in Path(tc).parents)

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -249,11 +249,11 @@ class Verdicts:
 
 
 class VerdictTable:
-    colors = {
-        'ACCEPTED': Fore.GREEN,
-        'WRONG_ANSWER': Fore.RED,
-        'TIME_LIMIT_EXCEEDED': Fore.MAGENTA,
-        'RUNTIME_ERROR': Fore.YELLOW,
+    colors = {#todo fix me
+        Verdict.ACCEPTED: Fore.GREEN,
+        Verdict.WRONG_ANSWER: Fore.RED,
+        Verdict.TIME_LIMIT_EXCEEDED: Fore.MAGENTA,
+        Verdict.RUNTIME_ERROR: Fore.YELLOW,
     }
 
     def __init__(
@@ -352,7 +352,7 @@ class VerdictTable:
             if testcase in self.results[s]:
                 v = self.results[s][testcase]
                 res = VerdictTable.colors[v]
-                res += v[0].lower() if testcase in self.samples else v[0].upper()
+                res += str(v)[0].lower() if testcase in self.samples else str(v)[0].upper()
             elif s + 1 == len(self.results) and testcase in self.current_testcases:
                 res = Style.DIM + Fore.BLUE + '?'
         return res + Style.RESET_ALL

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -203,27 +203,25 @@ class Verdicts:
     def salient_testcase(self) -> str:
         """The testcase most salient to the root verdict.
         If self['.'] is Verdict.ACCEPTED, then this is the slowest testcase.
-        If self['.'] is Verdict.TIME_LIMIT_EXCEEDED, then this is the slowest testcase with TLE verdict.
         Otherwise it is the lexicographically first testcase that was rejected."""
         with self:
             match self['.']:
                 case None:
                     raise ValueError("Salient testcase called before submission verdict determined")
-                # 'ACCEPTED | TIME_LIMIT_EXCEEDED' is only for python >=3.10.
                 case Verdict.ACCEPTED:
-                    return max((v, tc) for tc, v in self.duration.items())[1]
-                case Verdict.TIME_LIMIT_EXCEEDED:
-                    return max(
-                        (v, tc)
-                        for tc, v in self.duration.items()
-                        if self._verdict[k] == Verdict.TIME_LIMIT_EXCEEDED
-                    )[1]
+                    # This implicitly assumes there is at least one testcase.
+                    return max((d, tc) for tc, d in self.duration.items() if d is not None)[1]
                 case _:
                     return min(
                         tc
                         for tc, v in self._verdict.items()
-                        if self.is_testcase(k) and v is not Verdict.ACCEPTED
+                        if self.is_testcase(k) and v != Verdict.ACCEPTED
                     )
+
+    def slowest_testcase(self) -> str:
+        """The slowest testcase."""
+        with self:
+            return max((v, tc) for tc, v in self.duration.items())[1]
 
     def aggregate(self, testgroup: str) -> Verdict:
         """The aggregate verdict at the given testgroup.

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -71,8 +71,7 @@ def from_string(s: str) -> Verdict:
         case 'CHECK-MANUALLY':
             raise NotImplementedError
         case _:
-            return None
-            # raise ValueError(f"Unknown verdict string {s}")
+            raise ValueError(f"Unknown verdict string {s}")
 
 
 class Verdicts:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -158,9 +158,9 @@ class Verdicts:
         return self._verdict[testnode]
 
     def salient_testcase(self) -> str:
-        """The testcase most salient to the root verdict. If self['.'] this is the
-        slowest testcase. Otherwise it is the lexicographically first testcase that
-        was rejected."""
+        """The testcase most salient to the root verdict. If 
+        self['.'] == Verdict.ACCEPTED then this is the slowest testcase. 
+        Otherwise it is the lexicographically first testcase that was rejected."""
         match self['.']:
             case None:
                 raise ValueError("Salient testcase called before submission verdict determined")

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -74,6 +74,26 @@ def from_string(s: str) -> Verdict:
             raise ValueError(f"Unknown verdict string {s}")
 
 
+def from_string_domjudge(s: str) -> Verdict:
+    match s:
+        case 'CORRECT' | 'ACCEPTED':
+            return Verdict.ACCEPTED
+        case 'WRONG-ANSWER' | 'WRONG_ANSWER':
+            return Verdict.WRONG_ANSWER
+        case 'TIMELIMIT' | 'TIME_LIMIT_EXCEEDED':
+            return Verdict.TIME_LIMIT_EXCEEDED
+        case 'RUN-ERROR' | 'RUN_TIME_ERROR':
+            return Verdict.RUNTIME_ERROR
+        case 'NO-OUTPUT':
+            return Verdict.WRONG_ANSWER
+        case 'COMPILER-ERROR':
+            return Verdict.COMPILER_ERROR
+        case 'CHECK-MANUALLY':
+            raise NotImplementedError
+        case _:
+            raise ValueError(f"Unknown DOMjudge verdict string {s}")
+
+
 class Verdicts:
     """The verdicts of a submission.
 

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -210,18 +210,24 @@ class Verdicts:
                     raise ValueError("Salient testcase called before submission verdict determined")
                 case Verdict.ACCEPTED:
                     # This implicitly assumes there is at least one testcase.
-                    return max((tc, d) for tc, d in self.duration.items() if d is not None, key=lambda x: x[1])
+                    return max(
+                        ((tc, d) for tc, d in self.duration.items() if d is not None),
+                        key=lambda x: x[1],
+                    )
                 case _:
-                    min(
-                        (tc, d)
+                    tc = min(
+                        tc
                         for tc, v in self._verdict.items()
                         if self.is_testcase(tc) and v != Verdict.ACCEPTED
                     )
+                    return (tc, self.duration[tc])
 
     def slowest_testcase(self) -> (str, float):
         """The slowest testcase."""
         with self:
-            max((tc, v) for tc, v in self.duration.items() if v is not None, key=lambda x: x[1])
+            return max(
+                ((tc, v) for tc, v in self.duration.items() if v is not None), key=lambda x: x[1]
+            )
 
     def aggregate(self, testgroup: str) -> Verdict:
         """The aggregate verdict at the given testgroup.

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -201,7 +201,7 @@ class Verdicts:
         with self:
             return self._verdict[testnode]
 
-    def salient_testcase(self) -> str:
+    def salient_testcase(self) -> (str, float):
         """The testcase most salient to the root verdict.
         If self['.'] is Verdict.ACCEPTED, then this is the slowest testcase.
         Otherwise, it is the lexicographically first testcase that was rejected."""
@@ -211,18 +211,18 @@ class Verdicts:
                     raise ValueError("Salient testcase called before submission verdict determined")
                 case Verdict.ACCEPTED:
                     # This implicitly assumes there is at least one testcase.
-                    return max((d, tc) for tc, d in self.duration.items() if d is not None)[1]
+                    return max((tc, d) for tc, d in self.duration.items() if d is not None, key=lambda x: x[1])
                 case _:
-                    return min(
-                        tc
+                    min(
+                        (tc, d)
                         for tc, v in self._verdict.items()
                         if self.is_testcase(tc) and v != Verdict.ACCEPTED
                     )
 
-    def slowest_testcase(self) -> str:
+    def slowest_testcase(self) -> (str, float):
         """The slowest testcase."""
         with self:
-            return max((v, tc) for tc, v in self.duration.items() if v is not None)[1]
+            max((tc, v) for tc, v in self.duration.items() if v is not None, key=lambda x: x[1])
 
     def aggregate(self, testgroup: str) -> Verdict:
         """The aggregate verdict at the given testgroup.

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -38,7 +38,7 @@ def to_string(v: Verdict | None):
     }[v]
 
 
-def to_char(v: Verdict | None):
+def to_char(v: Verdict | None, lower=False):
     return {
         Verdict.ACCEPTED: f'{Fore.GREEN}A{Style.RESET_ALL}',
         Verdict.WRONG_ANSWER: f'{Fore.RED}W{Style.RESET_ALL}',
@@ -249,7 +249,7 @@ class Verdicts:
 
 
 class VerdictTable:
-    colors = {#todo fix me
+    colors = {  # todo fix me
         Verdict.ACCEPTED: Fore.GREEN,
         Verdict.WRONG_ANSWER: Fore.RED,
         Verdict.TIME_LIMIT_EXCEEDED: Fore.MAGENTA,

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -29,7 +29,7 @@ class Verdict(Enum):
             Verdict.COMPILER_ERROR: 'COMPILER ERROR',
         }[self]
 
-    def abbrev(self):
+    def short(self):
         return {
             Verdict.ACCEPTED: 'AC',
             Verdict.WRONG_ANSWER: 'WA',

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -222,7 +222,7 @@ class Verdicts:
     def slowest_testcase(self) -> str:
         """The slowest testcase."""
         with self:
-            return max((v, tc) for tc, v in self.duration.items())[1]
+            return max((v, tc) for tc, v in self.duration.items() if v is not None)[1]
 
     def aggregate(self, testgroup: str) -> Verdict:
         """The aggregate verdict at the given testgroup.

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -260,6 +260,7 @@ class Verdicts:
 
             # possibly update first_unknown at parent
             if testnode == first_unknown:
+                # TODO: Loop and check this verdict is actually unknown.
                 try:
                     first_unknown = next(self._unknowns[parent])
                 except StopIteration:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -544,8 +544,8 @@ class TableProgressBar(ProgressBar):
         self.table.add_testcase(item.testcase.name)
         return super().start(item)
 
-    def done(self, success=True, message='', data=''):
-        return super().done(success, message, data)
+    def done(self, success=True, message='', data='', print_item=True):
+        return super().done(success, message, data, print_item)
 
     def finalize(self, *, print_done=True, message=None):
         with self:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -183,12 +183,14 @@ class Verdicts:
                 updated_node = self._set_verdict_for_node(parent, self.aggregate(parent))
         return updated_node
 
-    def as_tree(self, max_depth=None) -> str:
+    def as_tree(self, max_depth=None, show_root=False) -> str:
         result = []
         stack = [('.', '', '', True)]
         while stack:
             node, indent, prefix, last = stack.pop()
             result.append(f"{indent}{prefix}{node.split('/')[-1]}: {to_string(self.verdict[node])}")
+            if max_depth is not None and len(indent) >= 2 * max_depth:
+                continue
             children = sorted(self.children[node], reverse=True)
             pipe = ' ' if last else '│'
             first = True
@@ -205,7 +207,7 @@ class Verdicts:
             if testcases:
                 edge = '└' if first else '├'
                 result.append(indent + pipe + ' ' + edge + '─' + ''.join(reversed(testcases)))
-        return '\n'.join(result)
+        return '\n'.join(result[int(not show_root):])
 
 
 class VerdictTable:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -29,6 +29,16 @@ class Verdict(Enum):
             Verdict.COMPILER_ERROR: 'COMPILER ERROR',
         }[self]
 
+    def abbrev(self):
+        return {
+            Verdict.ACCEPTED: 'AC',
+            Verdict.WRONG_ANSWER: 'WA',
+            Verdict.TIME_LIMIT_EXCEEDED: 'TLE',
+            Verdict.RUNTIME_ERROR: 'RTE',
+            Verdict.VALIDATOR_CRASH: 'VC',
+            Verdict.COMPILER_ERROR: 'CE',
+        }[self]
+
     def color(self):
         return {
             Verdict.ACCEPTED: Fore.GREEN,

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -204,7 +204,7 @@ class Verdicts:
     def salient_testcase(self) -> str:
         """The testcase most salient to the root verdict.
         If self['.'] is Verdict.ACCEPTED, then this is the slowest testcase.
-        Otherwise it is the lexicographically first testcase that was rejected."""
+        Otherwise, it is the lexicographically first testcase that was rejected."""
         with self:
             match self['.']:
                 case None:
@@ -216,7 +216,7 @@ class Verdicts:
                     return min(
                         tc
                         for tc, v in self._verdict.items()
-                        if self.is_testcase(k) and v != Verdict.ACCEPTED
+                        if self.is_testcase(tc) and v != Verdict.ACCEPTED
                     )
 
     def slowest_testcase(self) -> str:

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -183,8 +183,8 @@ class Verdicts:
         """
         return node not in self.children
 
-    def __setitem__(self, testcase, verdict: str | Verdict):
-        """Set the verdict of the given testcase (implying possibly others)
+    def set(self, testcase, verdict: str | Verdict, duration: float | None):
+        """Set the verdict and duration of the given testcase (implying possibly others)
 
         verdict can be given as a Verdict or as a string using either long or
         short form ('ACCEPTED', 'AC', or Verdict.ACCEPTED).
@@ -192,6 +192,7 @@ class Verdicts:
         with self:
             if isinstance(verdict, str):
                 verdict = from_string(verdict)
+            self.duration[testcase] = duration
             self._set_verdict_for_node(testcase, verdict)
 
     def __getitem__(self, testnode) -> Verdict | None:

--- a/test/problems/hello/submissions/wrong_answer/test-fill-syslog.c
+++ b/test/problems/hello/submissions/wrong_answer/test-fill-syslog.c
@@ -2,8 +2,6 @@
  * Floods syslog and should fail with WRONG-ANSWER.
  * It must be checked manually that syslog is not flooded.
  * This should normally not happen if the runguard works correctly.
- *
- * @EXPECTED_RESULTS@: 
  */
 
 #include <stdio.h>

--- a/test/problems/hello/submissions/wrong_answer/test-fill-syslog.c
+++ b/test/problems/hello/submissions/wrong_answer/test-fill-syslog.c
@@ -3,7 +3,7 @@
  * It must be checked manually that syslog is not flooded.
  * This should normally not happen if the runguard works correctly.
  *
- * @EXPECTED_RESULTS@: CHECK-MANUALLY
+ * @EXPECTED_RESULTS@: 
  */
 
 #include <stdio.h>

--- a/test/test_verdicts.py
+++ b/test/test_verdicts.py
@@ -7,7 +7,7 @@ PATHS = ["sample/1", "sample/2", "secret/a/1", "secret/a/2", "secret/a/3", "secr
 
 class TestVerdicts:
     def test_inherited_inference(self):
-        verds = verdicts.Verdicts(PATHS)
+        verds = verdicts.Verdicts(PATHS, 1.0)
         verds.set("secret/a/1", AC, 0.5)
         verds.set("secret/a/2", AC, 0.5)
         verds.set("secret/a/3", AC, 0.5)
@@ -19,7 +19,7 @@ class TestVerdicts:
         assert verds["."] == AC
 
     def test_first_error(self):
-        verds = verdicts.Verdicts(PATHS)
+        verds = verdicts.Verdicts(PATHS, 1.0)
         assert all(verds.run_is_needed(f"secret/a/{i}") for i in range(1, 3))
         verds.set("secret/a/1", AC, 0.5)
         verds.set("secret/a/3", WA, 0.5)
@@ -38,7 +38,7 @@ class TestVerdicts:
         # This means that this test_efficiency() runs in quadratic time.
         size = 1000
         many_paths = [f"a/{i}" for i in range(size)]
-        verds = verdicts.Verdicts(many_paths)
+        verds = verdicts.Verdicts(many_paths, 1.0)
         evens = range(0, size, 2)
         odds = range(1, size, 2)
         for i in reversed(evens):
@@ -48,13 +48,13 @@ class TestVerdicts:
 
     def test_parent_overwrite(self):
         # If implemented badly, will overwrite verdict at `secret/a' (and crash)
-        verds = verdicts.Verdicts(PATHS)
+        verds = verdicts.Verdicts(PATHS, 1.0)
         verds.set("secret/a/1", WA, 0.5)
         assert verds["secret/a"] == WA
         verds.set("secret/a/2", WA, 0.5)  # should not try to write 'secret/a' again
 
     def test_slowest_testcase(self):
-        verds = verdicts.Verdicts(PATHS, verdicts.RunUntil.DURATION, 3)
+        verds = verdicts.Verdicts(PATHS, 3, verdicts.RunUntil.DURATION)
         verds.set("sample/1", AC, 0.5)
         verds.set("sample/2", AC, 0.5)
         verds.set("secret/a/1", "TLE", 2.9)

--- a/test/test_verdicts.py
+++ b/test/test_verdicts.py
@@ -8,30 +8,31 @@ PATHS = ["sample/1", "sample/2", "secret/a/1", "secret/a/2", "secret/a/3", "secr
 class TestVerdicts:
     def test_inherited_inference(self):
         verds = verdicts.Verdicts(PATHS)
-        assert verds.set("secret/a/1", AC) == "secret/a/1"
-        assert verds.set("secret/a/2", AC) == "secret/a/2"
-        assert verds.set("secret/a/3", AC) == "secret/a"
-        assert verds.set("secret/c", AC) == "secret/c"
-        assert verds.set("secret/b/1", AC) == "secret"
-        assert verds.set("sample/1", AC) == "sample/1"
-        assert verds.verdict["."] is None
-        assert verds.set("sample/2", AC) == '.'
+        verds["secret/a/1"] = AC
+        verds["secret/a/2"] = AC
+        verds["secret/a/3"] = AC
+        verds["secret/c"] = AC
+        verds["secret/b/1"] = AC
+        verds["sample/1"] = AC
+        assert verds["."] is None
+        verds["sample/2"] = AC
+        assert verds["."] == AC
 
     def test_first_error(self):
         verds = verdicts.Verdicts(PATHS)
         assert verds.num_unknowns["secret/a"] == 3
-        assert verds.set("secret/a/1", AC) == "secret/a/1"
-        assert verds.set("secret/a/3", WA) == "secret/a/3"
-        assert verds.verdict["secret/a"] is None
+        verds["secret/a/1"] = AC
+        verds["secret/a/3"] = WA
+        assert verds["secret/a"] is None
         assert verds.first_unknown["secret/a"] == "secret/a/2"
         assert verds.num_unknowns["secret/a"] == 1
-        assert verds.set("secret/a/2", WA) == "secret"
-        assert verds.verdict["secret/a"] == WA
-        assert verds.verdict["secret"] == WA
-        assert verds.verdict["."] is None
-        verds.set("sample/1", AC)
-        verds.set("sample/2", AC)
-        assert verds.verdict["."] == WA
+        verds["secret/a/2"] = WA
+        assert verds["secret/a"] == WA
+        assert verds["secret"] == WA
+        assert verds["."] is None
+        verds["sample/1"] = AC
+        verds["sample/2"] = AC
+        assert verds["."] == WA
 
     def test_efficiency(self):
         # If done badly, this takes quadratic time
@@ -41,14 +42,13 @@ class TestVerdicts:
         evens = range(0, size, 2)
         odds = range(1, size, 2)
         for i in reversed(evens):
-            verds.set(f"a/{i}", AC)
+            verds[f"a/{i}"] = AC
         for i in odds:
-            verds.set(f"a/{i}", AC)
+            verds[f"a/{i}"] = AC
 
     def test_parent_overwrite(self):
         # If implmented badly, will overwrite verdict at `secret/a' (and crash)
         verds = verdicts.Verdicts(PATHS)
-        verds.set("secret/a/1", WA)
-        assert verds.verdict['secret/a'] == WA
-        verds.set("secret/a/2", WA)  # should not try to write 'sexret/a' again
-
+        verds["secret/a/1"] = WA
+        assert verds['secret/a'] == WA
+        verds["secret/a/2"] = WA  # should not try to write 'sexret/a' again

--- a/test/test_verdicts.py
+++ b/test/test_verdicts.py
@@ -8,47 +8,57 @@ PATHS = ["sample/1", "sample/2", "secret/a/1", "secret/a/2", "secret/a/3", "secr
 class TestVerdicts:
     def test_inherited_inference(self):
         verds = verdicts.Verdicts(PATHS)
-        verds["secret/a/1"] = AC
-        verds["secret/a/2"] = AC
-        verds["secret/a/3"] = AC
-        verds["secret/c"] = AC
-        verds["secret/b/1"] = AC
-        verds["sample/1"] = AC
+        verds.set("secret/a/1", AC, 0.5)
+        verds.set("secret/a/2", AC, 0.5)
+        verds.set("secret/a/3", AC, 0.5)
+        verds.set("secret/c", AC, 0.5)
+        verds.set("secret/b/1", AC, 0.5)
+        verds.set("sample/1", AC, 0.5)
         assert verds["."] is None
-        verds["sample/2"] = AC
+        verds.set("sample/2", AC, 0.5)
         assert verds["."] == AC
 
     def test_first_error(self):
         verds = verdicts.Verdicts(PATHS)
-        assert verds.num_unknowns["secret/a"] == 3
-        verds["secret/a/1"] = AC
-        verds["secret/a/3"] = WA
+        assert all(verds.run_is_needed(f"secret/a/{i}") for i in range(1, 3))
+        verds.set("secret/a/1", AC, 0.5)
+        verds.set("secret/a/3", WA, 0.5)
         assert verds["secret/a"] is None
-        assert verds.first_unknown["secret/a"] == "secret/a/2"
-        assert verds.num_unknowns["secret/a"] == 1
-        verds["secret/a/2"] = WA
+        assert verds.run_is_needed("secret/a/2")
+        verds.set("secret/a/2", WA, 0.5)
         assert verds["secret/a"] == WA
         assert verds["secret"] == WA
         assert verds["."] is None
-        verds["sample/1"] = AC
-        verds["sample/2"] = AC
+        verds.set("sample/1", AC, 0.5)
+        verds.set("sample/2", AC, 0.5)
         assert verds["."] == WA
 
     def test_efficiency(self):
-        # If done badly, this takes quadratic time
-        size = 100000
+        # Setting a verdict takes linear time: it checks the verdicts of all siblings to determine the parent's verdict.
+        # This means that this test_efficiency() runs in quadratic time.
+        size = 1000
         many_paths = [f"a/{i}" for i in range(size)]
         verds = verdicts.Verdicts(many_paths)
         evens = range(0, size, 2)
         odds = range(1, size, 2)
         for i in reversed(evens):
-            verds[f"a/{i}"] = AC
+            verds.set(f"a/{i}", AC, 0.5)
         for i in odds:
-            verds[f"a/{i}"] = AC
+            verds.set(f"a/{i}", AC, 0.5)
 
     def test_parent_overwrite(self):
-        # If implmented badly, will overwrite verdict at `secret/a' (and crash)
+        # If implemented badly, will overwrite verdict at `secret/a' (and crash)
         verds = verdicts.Verdicts(PATHS)
-        verds["secret/a/1"] = WA
-        assert verds['secret/a'] == WA
-        verds["secret/a/2"] = WA  # should not try to write 'sexret/a' again
+        verds.set("secret/a/1", WA, 0.5)
+        assert verds["secret/a"] == WA
+        verds.set("secret/a/2", WA, 0.5)  # should not try to write 'secret/a' again
+
+    def test_slowest_testcase(self):
+        verds = verdicts.Verdicts(PATHS, verdicts.RunUntil.DURATION, 3)
+        verds.set("sample/1", AC, 0.5)
+        verds.set("sample/2", AC, 0.5)
+        verds.set("secret/a/1", "TLE", 2.9)
+        verds.set("secret/a/2", "RTE", 3.5)
+        verds.set("secret/a/3", "TLE", 3.2)
+        assert verds.salient_testcase() == ("secret/a/1", 2.9)
+        assert verds.slowest_testcase() == ("secret/a/2", 3.5)


### PR DESCRIPTION
Properly determine the verdicts for each testgroup.

- [x] Refactoring: introduce `verdict.py`
- [x] move util.VerdictTable to `verdict.py`
- [x] In `verdict.py`, provide method for `Run.run` to register verdicts per testcase as those are computed, inferring testgroup verdicts as these become determined. This registry overlaps with the current internal functionality of `VerdictTable` and needs to be unified. This is probably just `class VerdictForTestItem(Dict)`, mapping `str` (testcase and testgroup names) to `verdicts.Verdict`.
- [x] Rewrite `Run.run` to leave the inference of the final (root) verdict to `verdict.py` 
- [x] Possibly provide `tree`-like overview of verdicts per testcase in UI
- [ ] Possibly  move `Submission._get_expected_verdicts` and related code to `verdict.py`