### PR TITLE
Feat/aggresive

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -507,8 +507,9 @@ class TestcaseRule(Rule):
 
                     # TODO: Should the seed depend on white space? For now it does, but
                     # leading and trailing whitespace is stripped.
-                    seed_value = self.config.random_salt + yaml['generate'].strip()
-                    self.seed = (int(hash_string(seed_value), 16) + count_index * 2**16) % 2**31
+                    salt = self.config.random_salt + ('' if count_index == 0 else f':{count_index}')
+                    seed_value = salt + yaml['generate'].strip()
+                    self.seed = int(hash_string(salt + yaml['generate'].strip()), 16) % 2**31
                     self.in_is_generated = True
                     self.rule['gen'] = self.generator.command_string
                     if self.generator.uses_seed:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -509,8 +509,8 @@ class TestcaseRule(Rule):
 
                     # TODO: Should the seed depend on white space? For now it does, but
                     # leading and trailing whitespace is stripped.
-                    salt = self.config.random_salt + ('' if count_index == 0 else f':{count_index}')
-                    seed_value = salt + yaml['generate'].strip()
+                    seed_value = self.config.random_salt + ('' if count_index == 0 else f':{count_index}')
+                    seed_value = seed_value + yaml['generate'].strip()
                     self.seed = int(hash_string(salt + yaml['generate'].strip()), 16) % 2**31
                     self.in_is_generated = True
                     self.rule['gen'] = self.generator.command_string

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -513,7 +513,7 @@ class TestcaseRule(Rule):
                     if count_index > 0:
                         seed_value += f':{count_index}'
                     seed_value += yaml['generate'].strip()
-                    self.seed = int(hash_string(salt + yaml['generate'].strip()), 16) % 2**31
+                    self.seed = int(hash_string(seed_value), 16) % 2**31
                     self.in_is_generated = True
                     self.rule['gen'] = self.generator.command_string
                     if self.generator.uses_seed:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -509,8 +509,10 @@ class TestcaseRule(Rule):
 
                     # TODO: Should the seed depend on white space? For now it does, but
                     # leading and trailing whitespace is stripped.
-                    seed_value = self.config.random_salt + ('' if count_index == 0 else f':{count_index}')
-                    seed_value = seed_value + yaml['generate'].strip()
+                    seed_value = self.config.random_salt
+                    if count_index > 0:
+                        seed_value += f':{count_index}'
+                    seed_value += yaml['generate'].strip()
                     self.seed = int(hash_string(salt + yaml['generate'].strip()), 16) % 2**31
                     self.in_is_generated = True
                     self.rule['gen'] = self.generator.command_string

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -245,7 +245,7 @@ class SolutionInvocation(Invocation):
 
 
 # Return absolute path to default submission, starting from the submissions directory.
-# This function will always raise a warning.
+# This function will always prints a message.
 # Which submission is used is implementation defined, unless one is explicitly given on the command line.
 def default_solution_path(generator_config):
     problem = generator_config.problem
@@ -278,16 +278,18 @@ solution: /{config.args.default_solution}''',
         solution_short_path = solution.relative_to(problem.path / 'submissions')
 
         if generator_config.has_yaml:
+            yaml_path = problem.path / 'generators' / 'generators.yaml'
+            raw = yaml_path.read_text()
+            raw = f'solution: /{solution.relative_to(problem.path)}\n' + raw
+            yaml_path.write_text(raw)
             message(
-                f'''No solution specified. Using {solution_short_path}.
-Set the default solution in the generator.yaml:
-solution: /{solution.relative_to(problem.path)}''',
+                f'No solution specified. {solution_short_path} added as default solution in the generator.yaml',
                 'generators.yaml',
-                color_type=MessageType.ERROR,
+                color_type=MessageType.LOG,
             )
         else:
             log(
-                f'''No solution specified. Using {solution_short_path}. Use
+                f'''No solution specified. Selected {solution_short_path}. Use
 --default_solution {solution.relative_to(problem.path)}
 to use a specific solution.'''
             )

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -110,16 +110,16 @@ class Problem:
             'uuid': None,
         }
 
-        yamlpath = self.path / 'problem.yaml'
+        yaml_path = self.path / 'problem.yaml'
 
         # parse problem.yaml
         if has_ryaml:
             try:
-                yamldata = read_yaml_settings(yamlpath)
+                yamldata = read_yaml_settings(yaml_path)
             except ruamel.yaml.scanner.ScannerError:
                 fatal('Make sure problem.yaml does not contain any more {% ... %}.')
         else:
-            yamldata = read_yaml_settings(yamlpath)
+            yamldata = read_yaml_settings(yaml_path)
 
         if yamldata:
             for k, v in yamldata.items():
@@ -166,9 +166,9 @@ class Problem:
 
         if self.settings.uuid == None:
             self.settings.uuid = generate_problem_uuid()
-            raw = yamlpath.read_text().rstrip()
+            raw = yaml_path.read_text().rstrip()
             raw += f'\n# uuid added by BAPCtools\nuuid: {self.settings.uuid}\n'
-            yamlpath.write_text(raw)
+            yaml_path.write_text(raw)
             log(f'Generated UUID for {self.name}, added to problem.yaml')
 
     def get_testdata_yaml(p, path, key, bar, name=None) -> str | None:

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -541,7 +541,7 @@ Run this from one of:
         '--default-solution',
         '-s',
         type=Path,
-        help='The default solution to use for generating .ans files.',
+        help='The default solution to use for generating .ans files. Not compatible with generator.yaml.',
     )
     genparser.add_argument(
         '--no-validators',

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -232,26 +232,26 @@ prolog:
     run: '{binary}'
 
 # By default Use pypy for python.
-# .py defaults to Python 2 unless a Python 3 shebang is found.
+# .py defaults to Python 3 unless a Python 2 shebang is found.
 python2:
     name: 'Python 2'
     priority: 900
-    files: '*.py *.py2'
+    files: '*.py2'
+    compile: 'pypy -m py_compile {files}'
+    run: 'pypy {mainfile}'
+
+python2b:
+    name: 'Python 2'
+    priority: 902
+    files: '*.py'
+    shebang: '^#!.*(python2\b|pypy\b)'
     compile: 'pypy -m py_compile {files}'
     run: 'pypy {mainfile}'
 
 python3:
     name: 'Python 3'
     priority: 901
-    files: '*.py3'
-    compile: 'pypy3 -m py_compile {files}'
-    run: 'pypy3 {mainfile}'
-
-python3b:
-    name: 'Python 3'
-    priority: 902
-    files: '*.py'
-    shebang: '^#!.*(python3\b|pypy3\b)'
+    files: '*.py *.py3'
     compile: 'pypy3 -m py_compile {files}'
     run: 'pypy3 {mainfile}'
 
@@ -259,22 +259,22 @@ python3b:
 cpython2:
     name: 'CPython 2'
     priority: 800
-    files: '*.py *.py2'
+    files: '*.py2'
+    compile: 'python2 -m py_compile {files}'
+    run: 'python2 {mainfile}'
+
+cpython2b:
+    name: 'CPython 2'
+    priority: 802
+    files: '*.py'
+    shebang: '^#!.*(python2\b|pypy\b)'
     compile: 'python2 -m py_compile {files}'
     run: 'python2 {mainfile}'
 
 cpython3:
     name: 'CPython 3'
     priority: 801
-    files: '*.py3'
-    compile: 'python3 -m py_compile {files}'
-    run: 'python3 {mainfile}'
-
-cpython3b:
-    name: 'CPython 3'
-    priority: 802
-    files: '*.py'
-    shebang: '^#!.*(python3\b|pypy3\b)'
+    files: '*.py *.py3'
     compile: 'python3 -m py_compile {files}'
     run: 'python3 {mainfile}'
 

--- a/doc/generators.yaml
+++ b/doc/generators.yaml
@@ -8,7 +8,7 @@
 #
 # This must be the absolute path to the solution, starting in the problem root.
 #
-# TOOLING: may pick a default if not specified, but should raise a warning.
+# TOOLING: may pick a default if not specified, but should raise an error.
 solution: /submissions/accepted/sol.py
 
 # The visualizer is used when no suitable image was generated already.


### PR DESCRIPTION
This changes the following things:

1. python3 is the default. Python2 is deprecated anyway and even problemtools changed their default
2. we no longer warn for missing UUID, we just add them (this even works without ruayaml)
3. Made the hash more random in case the new `count` keyword is used. (Nothing changed for rules without count)
4. the solution in `generator.yaml` is now mandatory. If it is missing we pick a solution and add the missing entry (again without ruayaml).

Please note that the previous behavior for 4 was buggy. We picked a random submission but overwrote the hashing therefore the `.ans` file weren't necessarily created by the solution we displayed but by some other solution on a previous run...