### PR TITLE
generate.py: avoid involuntary substring search

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1370,7 +1370,7 @@ class GeneratorConfig:
         testcase_id = 0
 
         def parse_count(yaml, warn_for=None):
-            if yaml is None or 'count' not in yaml or not isinstance(yaml['count'], int):
+            if yaml is None or not isinstance(yaml, dict) or 'count' not in yaml or not isinstance(yaml['count'], int):
                 return 1
             count = yaml['count']
             if count < 1:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1370,7 +1370,7 @@ class GeneratorConfig:
         testcase_id = 0
 
         def parse_count(yaml, warn_for=None):
-            if yaml is None or not isinstance(yaml, dict) or 'count' not in yaml or not isinstance(yaml['count'], int):
+            if not isinstance(yaml, dict) or 'count' not in yaml or not isinstance(yaml['count'], int):
                 return 1
             count = yaml['count']
             if count < 1:

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1370,7 +1370,11 @@ class GeneratorConfig:
         testcase_id = 0
 
         def parse_count(yaml, warn_for=None):
-            if not isinstance(yaml, dict) or 'count' not in yaml or not isinstance(yaml['count'], int):
+            if (
+                not isinstance(yaml, dict)
+                or 'count' not in yaml
+                or not isinstance(yaml['count'], int)
+            ):
                 return 1
             count = yaml['count']
             if count < 1:


### PR DESCRIPTION
This fixes a bug that occurs when a generator invocation contains the substring "count", for instance if a generator is called `counts.py`.