### PR TITLE
interactive.py: fix variable name

### DIFF
--- a/bin/interactive.py
+++ b/bin/interactive.py
@@ -151,7 +151,7 @@ def run_interactive_testcase(
             if not validator_err:
                 validator_err = bytes()
 
-            if not result.verdict and not self._continue_with_tle(verdict, max_duration >= timeout):
+            if tle_result and (not tle_result.verdict and not self._continue_with_tle(verdict, max_duration >= timeout)):
                 break
             elif not run._prepare_nextpass(nextpass):
                 break


### PR DESCRIPTION
Per the README, I wanted to let you know I've been using BAPCTools locally to develop ICPC problems for North American Regional contests, the North American Championships, and the World Finals. Thanks for making the tool. 😄 

I'm not 100% clear on the logic here, but this at least allows interactive problems to work on OSX.

Before:
```
$ bt run
Traceback (most recent call last):
  File "bin/bt", line 1079, in <module>
    main()
  File "bin/bt", line 1075, in main
    run_parsed_arguments(parser.parse_args())
  File "bin/bt", line 945, in run_parsed_arguments
    success &= problem.run_submissions()
  File "BAPCtools/bin/problem.py", line 649, in run_submissions
    submission_ok, printed_newline = submission.run_all_testcases(
  File "BAPCtools/bin/run.py", line 421, in run_all_testcases
    p.done()
  File "BAPCtools/bin/parallel.py", line 208, in done
    self._handle_first_error()
  File "BAPCtools/bin/parallel.py", line 173, in _handle_first_error
    raise first_error
  File "BAPCtools/bin/parallel.py", line 150, in _worker
    self.f(task)
  File "BAPCtools/bin/run.py", line 354, in process_run
    result = run.run(localbar)
  File "BAPCtools/bin/run.py", line 47, in run
    result = interactive.run_interactive_testcase(
  File "BAPCtools/bin/interactive.py", line 154, in run_interactive_testcase
    if not result.verdict and not self._continue_with_tle(verdict, max_duration >= timeout):
NameError: name 'result' is not defined
```

After:
```
$ bt run
<works as expected>
```