### PR TITLE
removed deprecated typing

### DIFF
--- a/bin/fuzz.py
+++ b/bin/fuzz.py
@@ -6,7 +6,7 @@ import generate
 import time
 import threading
 from colorama import Fore, Style
-from typing import Callable
+from collections.abc import Callable
 
 import parallel
 from util import *

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -8,8 +8,9 @@ import collections
 import shutil
 import secrets
 
+from collections.abc import Callable
 from pathlib import Path, PurePosixPath, PurePath
-from typing import Callable, Literal, overload
+from typing import Literal, overload
 
 import config
 import inspect

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from colorama import Fore, Style
 
@@ -179,7 +179,7 @@ def get_tl(problem: "problem.Problem"):
     return tl if print_tl else ''
 
 
-def make_environment() -> Dict[str, str]:
+def make_environment() -> dict[str, str]:
     env = os.environ.copy()
     # Search the contest directory and the latex directory.
     latex_paths = [

--- a/bin/parallel.py
+++ b/bin/parallel.py
@@ -3,7 +3,8 @@ import heapq
 import os
 import signal
 import threading
-from typing import Any, Callable, Generic, Literal, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, Generic, Literal, Optional, TypeVar
 
 import config
 import util

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -4,8 +4,9 @@ import shlex
 import sys
 import threading
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal, Optional, Type, TYPE_CHECKING
+from typing import Literal, Optional, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:  # Prevent circular import: https://stackoverflow.com/a/39757388
     from program import Program

--- a/bin/stats.py
+++ b/bin/stats.py
@@ -1,6 +1,6 @@
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from colorama import Fore, Style
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -14,8 +14,9 @@ import tempfile
 import threading
 import time
 from enum import Enum
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, NoReturn, Optional, Sequence
+from typing import Any, NoReturn, Optional
 
 import yaml as yamllib
 from colorama import Fore, Style


### PR DESCRIPTION
Seems like python 3.9 deprecated some of those typing stuff https://docs.python.org/3/library/typing.html