### PR TITLE
add bt timelimit

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -96,7 +96,7 @@ grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_
 grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
 # fmt: off
-args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'sort', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web']
+args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'sort', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web', 'write']
 # fmt: on
 
 

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -459,7 +459,7 @@ class Problem:
         if config.args.submissions:
             return submissions
         else:
-            return [s for s in submissions if verdicts.Verdict.ACCEPTED in s.expected_verdicts]
+            return [s for s in submissions if s.expected_verdicts == [verdicts.Verdict.ACCEPTED]]
 
     def submissions(problem) -> list[run.Submission] | Literal[False]:
         if problem._submissions is not None:

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -981,7 +981,7 @@ class Problem:
                 error(f'TLE submission runs within timelimit')
             elif duration <= safety_timelimit:
                 warn(f'TLE submission runs within safety margin')
-            else:
+            elif duration >= problem.settings.timeout:
                 log(
                     f'No TLE submission finished within {problem.settings.timeout}s >= {problem.settings.timelimit:.3f}s * {problem.limits.time_safety_margin}^2'
                 )

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -686,7 +686,7 @@ class Problem:
             ok &= submission_ok
 
         if config.args.table:
-            Problem._print_table(verdict_table.results, testcases, submissions)
+            Problem._print_table(verdict_table.results, testcases)
         elif config.args.overview and not config.args.tree:
             verdict_table.print(force=True, new_lines=1)
 
@@ -709,7 +709,7 @@ class Problem:
         return True
 
     @staticmethod
-    def _print_table(verdict_table, testcases, submissions):
+    def _print_table(verdict_table, testcases):
         # Begin by aggregating bitstrings for all testcases, and find bitstrings occurring often (>=config.TABLE_THRESHOLD).
         def single_verdict(row, testcase):
             assert row[testcase.name] is not None

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -931,6 +931,10 @@ class Problem:
             nonlocal ok
 
             cur_submissions = [s for s in submissions if select_verdict(s.expected_verdicts)]
+
+            if len(cur_submissions) == 0:
+                return None, None, None
+
             verdict_table = verdicts.VerdictTable(cur_submissions, testcases)
             needs_leading_newline = False if config.args.verbose else True
             for submission in cur_submissions:
@@ -941,9 +945,6 @@ class Problem:
                 )
                 needs_leading_newline = not printed_newline
                 ok &= submission_ok
-
-            if not verdict_table.results:
-                return None, None, None
 
             def get_slowest(result):
                 slowest_pair = result.slowest_testcase()
@@ -957,6 +958,7 @@ class Problem:
 
         submission, testcase, duration = run_all(lambda vs: vs == [verdicts.Verdict.ACCEPTED], max)
         if submission is None:
+            error('No AC submissions found')
             return False
 
         problem.settings.timelimit = problem.limits.time_resolution * math.ceil(
@@ -991,6 +993,8 @@ class Problem:
                     f'No TLE submission finished within {problem.settings.timeout}s >= {problem.settings.timelimit:.3f}s * {problem.limits.time_safety_margin}^2'
                 )
             print()
+        else:
+            log('No TLE submissions found')
 
         if config.args.all:
             submission, testcase, duration = run_all(

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -176,7 +176,7 @@ class Problem:
         settings_limits = settings['limits']
         settings.pop('limits')
         assert isinstance(settings_limits, dict)
-        for k, v in settings_limits:
+        for k, v in settings_limits.items():
             limits[k] = v
 
         # Convert the dictionary to a namespace object.

--- a/bin/run.py
+++ b/bin/run.py
@@ -337,7 +337,11 @@ class Submission(program.Program):
         padding_len = max_submission_name_len - len(self.name)
         run_until = RunUntil.FIRST_ERROR
 
-        if config.args.all == 1 or config.args.verbose or config.args.action == 'all':
+        if (
+            config.args.all == 1
+            or config.args.verbose
+            or config.args.action in ['all', 'timelimit']
+        ):
             run_until = RunUntil.DURATION
         if config.args.all == 2:
             run_until = RunUntil.ALL
@@ -453,7 +457,7 @@ class Submission(program.Program):
         # Summary line is the only thing shown.
         message = f'{color}{salient_print_verdict.short():>3}{salient_duration_style}{salient_duration:6.3f}s{Style.RESET_ALL} {Style.DIM}@ {salient_testcase:{max_testcase_len}}{Style.RESET_ALL}'
 
-        if run_until in [RunUntil.DURATION, RunUntil.ALL]:
+        if verdicts.run_until in [RunUntil.DURATION, RunUntil.ALL]:
             slowest_pair = verdicts.slowest_testcase()
             assert slowest_pair is not None
             (slowest_testcase, slowest_duration) = slowest_pair

--- a/bin/run.py
+++ b/bin/run.py
@@ -295,6 +295,7 @@ class Submission(program.Program):
                         f'Submission {self.short_path} must have @EXPECTED_RESULTS@. Defaulting to ACCEPTED.'
                     )
 
+        expected_verdicts.sort()
         return expected_verdicts or [Verdict.ACCEPTED]
 
     # Run submission on in_path, writing stdout to out_path or stdout if out_path is None.

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -641,6 +641,28 @@ Run this from one of:
         help='Run submissions with additional sanitizer flags (currently only C++). Note that this sets --memory unlimited.',
     )
 
+    timelimitparser = subparsers.add_parser(
+        'timelimit', parents=[global_parser], help='Determine the timelimit for a problem.'
+    )
+    timelimitparser.add_argument(
+        'submissions',
+        nargs='*',
+        type=Path,
+        help='optionally supply a list of programs and testcases on which the timelimit should be based.',
+    )
+    timelimitparser.add_argument(
+        '--all',
+        '-a',
+        action='store_true',
+        help='Run all submissions, not only AC and TLE.',
+    )
+    timelimitparser.add_argument(
+        '--write',
+        '-w',
+        action='store_true',
+        help='Write .timelimit file.',
+    )
+
     # Test
     testparser = subparsers.add_parser(
         'test', parents=[global_parser], help='Run a single program and print the output.'
@@ -955,6 +977,8 @@ def run_parsed_arguments(args):
             success &= problem.test_submissions()
         if action in ['constraints']:
             success &= constraints.check_constraints(problem)
+        if action in ['timelimit']:
+            success &= problem.determine_timelimit()
         if action in ['zip']:
             output = problem.path / f'{problem.name}.zip'
 

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -822,7 +822,7 @@ def run_parsed_arguments(args):
     action = config.args.action
 
     # Split submissions and testcases when needed.
-    if action in ['run', 'fuzz']:
+    if action in ['run', 'fuzz', 'timelimit']:
         if config.args.submissions:
             config.args.submissions, config.args.testcases = split_submissions_and_testcases(
                 config.args.submissions

--- a/bin/util.py
+++ b/bin/util.py
@@ -3,6 +3,7 @@
 import copy
 import errno
 import hashlib
+import math
 import os
 import platform
 import secrets
@@ -1037,6 +1038,8 @@ def exec_command(
         elif kwargs['timeout']:
             timeout = kwargs['timeout']
         kwargs.pop('timeout')
+    if timeout is not None and math.isinf(timeout):
+        timeout = None
 
     if (is_windows() or is_wsl()) and 'memory' in kwargs:
         kwargs.pop('memory')

--- a/bin/verdicts.py
+++ b/bin/verdicts.py
@@ -33,6 +33,9 @@ class Verdict(Enum):
             Verdict.COMPILER_ERROR: 'COMPILER ERROR',
         }[self]
 
+    def __lt__(self, other):
+        return self.value < other.value
+
     def short(self):
         return {
             Verdict.ACCEPTED: 'AC',
@@ -373,9 +376,7 @@ class VerdictTable:
         height: int = shutil.get_terminal_size().lines,
         max_name_width: int = 50,
     ):
-        self.submissions: list[str] = [
-            submission.name for verdict in submissions for submission in submissions[verdict]
-        ]
+        self.submissions: list[str] = [s.name for s in submissions]
         self.testcases: list[str] = [t.name for t in testcases]
         self.samples: set[str] = set(t.name for t in testcases if t.root == 'sample')
         self.results: list[Verdicts] = []

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -14,6 +14,7 @@ This lists all subcommands and their most important options.
 - Problem development:
   - [`bt run [-v] [-t TIMELIMIT] [submissions [submissions ...]] [testcases [testcases ...]]`](#run)
   - [`bt test [-v] [-t TIMEOUT] submission [--interactive | --samples | [testcases [testcases ...]]]`](#test)
+  - [`bt timelimit [-a] [-w] [submissions [submissions ...]] [testcases [testcases ...]]`](#timelimit)
   - [`bt generate [-v] [-t TIMEOUT] [--add] [--clean] [--check-deterministic] [--jobs JOBS] [--no-validators] [--no-visualizer] [testcases [testcases ...]]`](#generate)
   - [`bt pdf [-v] [--all] [--web] [--cp] [--no-timelimit]`](#pdf)
   - [`bt solutions [-v] [--web] [--cp] [--order ORDER]`](#solutions)
@@ -143,6 +144,21 @@ This is useful for running submissions without having to compile them manually. 
 - `[<testcases>]`: The testcases to run the submission on. See `run <testcases>` for more. Can not be used together with `--samples`.
 - `--samples`: Run the submission on the samples only. Can not be used together with explicitly listed testcases.
 - `--timeout <second>`/`-t <second>`: The timeout to use for the submission.
+
+## `timelimit`
+
+The `timelimit` command is used determine a timelimit based on `time_multiplier` and `time_safety_margin`.
+The syntax is:
+
+```
+bt timelimit [<submissions and/or testcases>]
+```
+
+**Flags**
+- `--write`/`-w`: write the determined timelimit to `.timelimit`
+- `--all`/`-a`: run all submissions not only AC and TLE submissions.
+- `<submission>`: The path to the submission to use to determine the timelimit. See `run <submissions>` for more.
+- `<testcases>`: The path to the testcases to use determine the timelimit. See `run <testcases>` for more.
 
 ## `generate`
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -147,7 +147,7 @@ This is useful for running submissions without having to compile them manually. 
 
 ## `timelimit`
 
-The `timelimit` command is used determine a timelimit based on `time_multiplier` and `time_safety_margin`.
+The `timelimit` command is used determine a timelimit based on `time_multiplier` (factor on top of the slowest AC submission) and `time_safety_margin` (range in which a warning for an TLE submission is raised).
 The syntax is:
 
 ```
@@ -157,7 +157,7 @@ bt timelimit [<submissions and/or testcases>]
 **Flags**
 - `--write`/`-w`: write the determined timelimit to `.timelimit`
 - `--all`/`-a`: run all submissions not only AC and TLE submissions.
-- `<submission>`: The path to the submission to use to determine the timelimit. See `run <submissions>` for more.
+- `<submissions>`: The path to the submission to use to determine the timelimit. See `run <submissions>` for more.
 - `<testcases>`: The path to the testcases to use determine the timelimit. See `run <testcases>` for more.
 
 ## `generate`


### PR DESCRIPTION
This adds the command `bt timelimit` that tries to determine the timelimit in a similar way that `problemtools` does.
Since this needs to run at least all AC and TLE submissions its a separate command and not included with run (your should rarely need to re determine the timelimit).