### PR TITLE
Reorder

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -96,7 +96,7 @@ grep '^  [^ ]' | sed 's/^  //' | cut -d ' ' -f 1 | sed -E 's/,//;s/^-?-?//;s/-/_
 grep -Ev '^(h|jobs|time|verbose)$' | sed "s/^/'/;s/$/',/" | tr '\n' ' ' | sed 's/^/args_list = [/;s/, $/]\n/'
 """
 # fmt: off
-args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'samples', 'sanitizer', 'skel', 'skip', 'sort', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web', 'write']
+args_list = ['1', 'add', 'all', 'answer', 'api', 'author', 'check_deterministic', 'clean', 'colors', 'contest', 'contest_id', 'contestname', 'cp', 'default_solution', 'depth', 'directory', 'error', 'force', 'force_build', 'input', 'interaction', 'interactive', 'invalid', 'kattis', 'language', 'memory', 'move_to', 'no_bar', 'no_generate', 'no_solution', 'no_solutions', 'no_testcase_sanity_checks', 'no_timelimit', 'no_validators', 'no_visualizer', 'open', 'order', 'order_from_ccs', 'overview', 'password', 'post_freeze', 'problem', 'problemname', 'remove', 'reorder', 'samples', 'sanitizer', 'skel', 'skip', 'sort', 'submissions', 'table', 'testcases', 'timelimit', 'timeout', 'token', 'tree', 'username', 'validation', 'watch', 'web', 'write']
 # fmt: on
 
 

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -1210,10 +1210,7 @@ class Directory(Rule):
             return
         assert_type('Data', data, [dict, list])
 
-        if isinstance(data, dict):
-            yaml['data'] = [data]
-            data = yaml['data']
-        else:
+        if isinstance(data, list):
             self.numbered = True
             if len(data) == 0:
                 return
@@ -1601,9 +1598,10 @@ class GeneratorConfig:
 
             # Parse child directories/testcases.
             if 'data' in yaml and yaml['data']:
+                data = yaml['data'] if isinstance(yaml['data'], list) else [yaml['data']]
                 # Count the number of child testgroups.
                 num_testgroups = 0
-                for dictionary in yaml['data']:
+                for dictionary in data:
                     assert_type('Elements of data', dictionary, dict, d.path)
                     for key in dictionary.keys():
                         assert_type('Key of data', key, [type(None), str], d.path / str(key))
@@ -1612,7 +1610,7 @@ class GeneratorConfig:
                             num_testgroups += 1
 
                 testgroup_id = 0
-                for dictionary in yaml['data']:
+                for dictionary in data:
                     for key in dictionary:
                         assert_type('Testcase/directory name', key, [type(None), str], d.path)
 

--- a/bin/run.py
+++ b/bin/run.py
@@ -328,9 +328,9 @@ class Submission(program.Program):
     # Run this submission on all testcases for the current problem.
     # Returns (OK verdict, printed newline)
     def run_all_testcases(
-        self, max_submission_name_len: int, verdict_table, *, needs_leading_newline
+        self, max_submission_name_len: int, verdict_table, testcases, *, needs_leading_newline
     ):
-        runs = [Run(self.problem, self, testcase) for testcase in self.problem.testcases()]
+        runs = [Run(self.problem, self, testcase) for testcase in testcases]
         max_testcase_len = max(len(run.name) for run in runs)
         if self.problem.multipass:
             max_testcase_len += 2
@@ -344,11 +344,11 @@ class Submission(program.Program):
             or config.args.action in ['all', 'timelimit']
         ):
             run_until = RunUntil.DURATION
-        if config.args.all == 2:
+        if config.args.all == 2 or config.args.reorder:
             run_until = RunUntil.ALL
 
         verdicts = Verdicts(
-            self.problem.testcases(),
+            testcases,
             self.problem.settings.timeout,
             run_until,
         )

--- a/bin/tools.py
+++ b/bin/tools.py
@@ -524,6 +524,11 @@ Run this from one of:
     genparser_group.add_argument(
         '--clean', '-C', action='store_true', help='Delete all cached files.'
     )
+    genparser_group.add_argument(
+        '--reorder',
+        action='store_true',
+        help='Reorder cases by difficulty inside the given directories.',
+    )
 
     genparser.add_argument(
         '--interaction',
@@ -869,10 +874,24 @@ def run_parsed_arguments(args):
         checked_paths = []
         for path in config.args.add:
             if path.parts[0] != 'generators':
-                warn(f'Path {path} does not math "generators/*". Skipping.')
+                warn(f'Path {path} does not match "generators/*". Skipping.')
             else:
                 checked_paths.append(path)
         config.args.add = checked_paths
+
+    if config.args.reorder is not None:
+        # default to 'data/secret'
+        if not config.args.testcases:
+            config.args.testcases = [Path('data/secret')]
+
+        # Paths *must* be inside data/.
+        checked_paths = []
+        for path in config.args.testcases:
+            if path.parts[0] != 'data':
+                warn(f'Path {path} does not match "data/*". Skipping.')
+            else:
+                checked_paths.append(path)
+        config.args.testcases = checked_paths
 
     # Handle one-off subcommands.
     if action == 'tmp':

--- a/bin/util.py
+++ b/bin/util.py
@@ -31,6 +31,7 @@ try:
     ryaml = ruamel.yaml.YAML(typ='rt')
     ryaml.default_flow_style = False
     ryaml.indent(mapping=2, sequence=4, offset=2)
+    ryaml.width = sys.maxsize
 except Exception:
     has_ryaml = False
 
@@ -547,7 +548,7 @@ def path_size(path):
     if path.is_file():
         return path.stat().st_size
     else:
-        return sum(f.stat().st_size for f in path.rglob('*'))
+        return sum(f.stat().st_size for f in path.rglob('*') if f.exists())
 
 
 # Drops the first two path components <problem>/<type>/

--- a/test/test_generators_yaml.py
+++ b/test/test_generators_yaml.py
@@ -29,7 +29,7 @@ class MockGeneratorConfig(generate.GeneratorConfig):
         self.known_cases = dict()
         # A set of paths `secret/testgroup`.
         # Used for cleanup.
-        self.known_directories = set()
+        self.known_directories = dict()
         # Used for cleanup
         self.known_files = set()
         # A map from key to (is_included, list of testcases and directories),


### PR DESCRIPTION
add `bt generate --reorder` to reorder testcases by difficulty.

Some notes here:
-  I put this as a sub command of `bt generate` fore many reasons
   - This only works with `generator.yaml` and auto numbered cases
   - it heavily depends on the `GeneratorConfig` object
- the reordering needs to run all non AC submissions which is new for generate...
- the algorithm for reordering takes `|s|*|t|^2` time