### PR TITLE
[problem] Full support for problem.yaml with 2023-07-draft spec

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -1,5 +1,4 @@
-# Global variables that are constant after the programs arguments have been
-# parsed.
+# Global variables that are constant after the programs arguments have been parsed.
 
 import argparse
 import os
@@ -19,13 +18,14 @@ SUBMISSION_DIRS: Final[Sequence[str]] = [
     "run_time_error",
 ]
 
+# This ordering is shown in bt new_problem with questionary installed (intentionally non-alphabetical).
 KNOWN_LICENSES: Final[Sequence[str]] = [
-    "cc by",
     "cc by-sa",
+    "cc by",
     "cc0",
+    "public domain",
     "educational",
     "permission",
-    "public domain",
     "unknown",
 ]
 

--- a/bin/config.py
+++ b/bin/config.py
@@ -20,12 +20,12 @@ SUBMISSION_DIRS: Final[Sequence[str]] = [
 ]
 
 KNOWN_LICENSES: Final[Sequence[str]] = [
-    "cc by-sa",
     "cc by",
+    "cc by-sa",
     "cc0",
-    "public domain",
     "educational",
     "permission",
+    "public domain",
     "unknown",
 ]
 

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -203,7 +203,7 @@ def problem_data(problem: "problem.Problem", language: str):
     return {
         "problemlabel": problem.label,
         "problemyamlname": problem.settings.name[language].replace("_", " "),
-        "problemauthor": ", ".join(problem.settings.credits.authors),
+        "problemauthor": ", ".join(a.name for a in problem.settings.credits.authors),
         "problembackground": background,
         "problemforeground": foreground,
         "problemborder": border,

--- a/bin/latex.py
+++ b/bin/latex.py
@@ -203,7 +203,7 @@ def problem_data(problem: "problem.Problem", language: str):
     return {
         "problemlabel": problem.label,
         "problemyamlname": problem.settings.name[language].replace("_", " "),
-        "problemauthor": problem.settings.author,
+        "problemauthor": ", ".join(problem.settings.credits.authors),
         "problembackground": background,
         "problemforeground": foreground,
         "problemborder": border,

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -36,7 +36,7 @@ def parse_legacy_validation(mode: str) -> set[str]:
             else:
                 ok = False
         if "custom" not in parsed or not ok:
-            fatal(f"Unrecognised validation mode {mode}.")
+            fatal(f"problem.yaml: unrecognized validation mode {mode}.")
         return parsed
 
 
@@ -279,6 +279,13 @@ class ProblemSettings:
                 )
                 yaml_data.pop("validation")
             mode = set(parse_setting(yaml_data, "type", "pass-fail").split(" "))
+            unrecognized_type = mode - {"pass-fail", "interactive", "multi-pass"}
+            if unrecognized_type:
+                fatal(
+                    f"""problem.yaml: unrecognized value{
+                        "" if len(unrecognized_type) == 1 else "s"
+                    } for 'type': {" ".join(sorted(unrecognized_type))}"""
+                )
         self.interactive: bool = "interactive" in mode
         self.multi_pass: bool = "multi-pass" in mode
         self.custom_output: bool = (

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -242,9 +242,16 @@ class ProblemSettings:
         self.source_url: str = parse_setting(yaml_data, "source_url", "")
         self.license: str = parse_setting(yaml_data, "license", "unknown")
         self.rights_owner: str = parse_setting(yaml_data, "rights_owner", "")
+        # Not implemented in BAPCtools. Should be a date, but we don't do anything with this anyway.
+        self.embargo_until: str = parse_setting(yaml_data, "embargo-until", "")
         self.limits = ProblemLimits(parse_setting(yaml_data, "limits", {}), problem, self)
+        # TODO: move to testdata.yaml
         self.validator_flags: list[str] = parse_setting(yaml_data, "validator_flags", [])
         self.keywords: str = parse_setting(yaml_data, "keywords", "")
+        # Not implemented in BAPCtools. We always test all languges in langauges.yaml.
+        self.languages: list[str] = parse_optional_list_setting(yaml_data, "languages", str)
+        # Not yet implemented, pending https://github.com/Kattis/problem-package-format/issues/344
+        self.constants: dict[str, Any] = parse_setting(yaml_data, "constants", {})
 
         # BAPCtools extensions:
         self.verified: Optional[str] = parse_optional_setting(yaml_data, "verified", str)

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -287,7 +287,15 @@ class ProblemSettings:
                     "problem.yaml: 'validation' is removed in 2023-07-draft, please use 'type' instead. SKIPPED."
                 )
                 yaml_data.pop("validation")
-            mode = set(parse_setting(yaml_data, "type", "pass-fail").split(" "))
+            mode = set(
+                ["pass-fail"]
+                if "type" not in yaml_data
+                else parse_setting(yaml_data, "type", "pass-fail").split()
+                if isinstance(yaml_data["type"], str)
+                else parse_optional_list_setting(yaml_data, "type", str)
+                if isinstance(yaml_data["type"], list)
+                else [fatal("problem.yaml: 'type' must be a string or a sequence")]
+            )
             unrecognized_type = mode - {"pass-fail", "interactive", "multi-pass"}
             if unrecognized_type:
                 fatal(

--- a/bin/problem.py
+++ b/bin/problem.py
@@ -187,6 +187,7 @@ class ProblemSettings:
 
         self.name: dict[str, str] = parse_setting(yaml_data, "name", {"en": ""})
         self.uuid: str = parse_setting(yaml_data, "uuid", "")
+        self.version: str = parse_setting(yaml_data, "version", "")
         self.author: str = parse_setting(yaml_data, "author", "")
         self.source: str = parse_setting(yaml_data, "source", "")
         self.source_url: str = parse_setting(yaml_data, "source_url", "")

--- a/bin/skel.py
+++ b/bin/skel.py
@@ -131,7 +131,7 @@ def get_skel_dir(target_dir):
 def new_problem():
     target_dir = Path(".")
     if config.args.contest:
-        target_dir = Path(config.args.contest)
+        os.chdir(Path(config.args.contest))
     if config.args.problem:
         fatal("--problem does not work for new_problem.")
 
@@ -186,12 +186,14 @@ def new_problem():
     }.items():
         variables[k] = v
 
-    variables["source"] = _ask_variable_string(
+    source_name = _ask_variable_string(
         "source", variables.get("source", variables.get("name", "")), True
     )
-    variables["source_url"] = _ask_variable_string(
-        "source url", variables.get("source_url", ""), True
+    source_url = _ask_variable_string("source url", variables.get("source_url", ""), True)
+    variables["source"] = (
+        f"source:\n  name: {source_name}\n{'  url: {source_url}' if source_url else '  #url:'}"
     )
+
     variables["license"] = _ask_variable_choice(
         "license", config.KNOWN_LICENSES, variables.get("license", None)
     )

--- a/bin/util.py
+++ b/bin/util.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import (
     Any,
+    cast,
     Iterable,
     Literal,
     NoReturn,
@@ -763,8 +764,8 @@ def parse_optional_setting(yaml_data: dict[str, Any], key: str, t: type[T]) -> O
         if isinstance(value, int) and t is float:
             value = float(value)
         if isinstance(value, t):
-            return value
-        if value == "" and t is list or t is dict:
+            return cast(T, value)
+        if value == "" and (t is list or t is dict):
             # handle empty yaml keys
             return t()
         warn(f"incompatible value for key '{key}' in problem.yaml. SKIPPED.")

--- a/bin/util.py
+++ b/bin/util.py
@@ -757,9 +757,9 @@ def write_yaml(
 T = TypeVar("T")
 
 
-def parse_optional_setting(yamldata: dict[str, Any], key: str, t: type[T]) -> Optional[T]:
-    if key in yamldata:
-        value = yamldata.pop(key)
+def parse_optional_setting(yaml_data: dict[str, Any], key: str, t: type[T]) -> Optional[T]:
+    if key in yaml_data:
+        value = yaml_data.pop(key)
         if isinstance(value, int) and t is float:
             value = float(value)
         if isinstance(value, t):
@@ -772,8 +772,8 @@ def parse_optional_setting(yamldata: dict[str, Any], key: str, t: type[T]) -> Op
     return None
 
 
-def parse_setting(yamldata: dict[str, Any], key: str, default: T) -> T:
-    value = parse_optional_setting(yamldata, key, type(default))
+def parse_setting(yaml_data: dict[str, Any], key: str, default: T) -> T:
+    value = parse_optional_setting(yaml_data, key, type(default))
     return default if value is None else value
 
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -767,14 +767,29 @@ def parse_optional_setting(yaml_data: dict[str, Any], key: str, t: type[T]) -> O
         if value == "" and t is list or t is dict:
             # handle empty yaml keys
             return t()
-        else:
-            warn(f"incompatible value for key '{key}' in problem.yaml. SKIPPED.")
+        warn(f"incompatible value for key '{key}' in problem.yaml. SKIPPED.")
     return None
 
 
 def parse_setting(yaml_data: dict[str, Any], key: str, default: T) -> T:
     value = parse_optional_setting(yaml_data, key, type(default))
     return default if value is None else value
+
+
+def parse_optional_list_setting(yaml_data: dict[str, Any], key: str, t: type[T]) -> list[T]:
+    if key in yaml_data:
+        value = yaml_data.pop(key)
+        if isinstance(value, t):
+            return [value]
+        if isinstance(value, list):
+            if not all(isinstance(v, t) for v in value):
+                warn(
+                    f"some values for key '{key}' in problem.yaml do not have type {t.__name__}. SKIPPED."
+                )
+                return []
+            return value
+        warn(f"incompatible value for key '{key}' in problem.yaml. SKIPPED.")
+    return []
 
 
 # glob, but without hidden files

--- a/skel/problem/problem.yaml
+++ b/skel/problem/problem.yaml
@@ -5,7 +5,7 @@ name:
 {%problemname%}
 # 'pass-fail', 'interactive', 'multi-pass', or 'interactive multi-pass'
 type: {%type%}
-author: {%author%}
+credits: {%author%}
 # Contest name and year
 source: {%source%}
 # contest.region.eu

--- a/skel/problem/problem.yaml
+++ b/skel/problem/problem.yaml
@@ -1,16 +1,15 @@
 # Specification: https://icpc.io/problem-package-format/spec/2023-07-draft.html
 problem_format_version: 2023-07-draft
+# 'pass-fail', 'interactive', 'multi-pass', or 'interactive multi-pass'
+type: {%type%}
 name:
   #lang: name
 {%problemname%}
-# 'pass-fail', 'interactive', 'multi-pass', or 'interactive multi-pass'
-type: {%type%}
-credits: {%author%}
-# Contest name and year
-source: {%source%}
-# contest.region.eu
-source_url: {%source_url%}
 uuid: {%uuid%}
+credits: {%author%}
+source:
+  name: {%source%}
+  url: {%source_url%}
 license: {%license%}
 rights_owner: {%rights_owner%}
 

--- a/skel/problem/problem.yaml
+++ b/skel/problem/problem.yaml
@@ -7,9 +7,7 @@ name:
 {%problemname%}
 uuid: {%uuid%}
 credits: {%author%}
-source:
-  name: {%source%}
-  url: {%source_url%}
+{%source%}
 license: {%license%}
 rights_owner: {%rights_owner%}
 

--- a/test/test_problem_yaml.py
+++ b/test/test_problem_yaml.py
@@ -30,17 +30,23 @@ def read_tests(yaml_name) -> list[dict]:
 
 
 def assert_equal(obj: Any, expected: Any):
-    if not isinstance(expected, dict):
-        assert obj == expected
+    if isinstance(expected, list):
+        assert isinstance(obj, list), "Expected a list"
+        for a, b in zip(obj, expected):
+            assert_equal(a, b)
         return
 
-    for key, value in expected.items():
-        if hasattr(obj, key):
-            assert_equal(getattr(obj, key), value)
-        elif isinstance(obj, dict) and key in obj:
-            assert obj[key] == value
-        else:
-            assert False, f"Not supporting {obj}.{key} == {value}"
+    if isinstance(expected, dict):
+        for key, value in expected.items():
+            if hasattr(obj, key):
+                assert_equal(getattr(obj, key), value)
+            elif isinstance(obj, dict) and key in obj:
+                assert_equal(obj[key], value)
+            else:
+                assert False, f"Not supporting {obj}.{key} == {value}"
+
+    if not isinstance(expected, dict):
+        assert obj == expected
 
 
 class MockProblem:

--- a/test/test_problem_yaml.py
+++ b/test/test_problem_yaml.py
@@ -1,0 +1,86 @@
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import call, MagicMock
+
+import problem
+import config
+
+RUN_DIR = Path.cwd().resolve()
+
+config.args.verbose = 2
+config.args.error = True
+config.set_default_args()
+
+
+# return list of {yaml: {...}, ...} documents
+def read_tests(yaml_name) -> list[dict]:
+    docs = [
+        test
+        if "uuid" in test["yaml"]
+        else {**test, "yaml": {**test["yaml"], "uuid": "00000000-0000-0000-0000-000000000000"}}
+        for test in yaml.load_all(
+            (RUN_DIR / f"test/yaml/problem/{yaml_name}.yaml").read_text(),
+            Loader=yaml.SafeLoader,
+        )
+    ]
+    assert isinstance(docs, list) and all(isinstance(doc, dict) for doc in docs), docs
+    return docs
+
+
+def assert_equal(obj, expected):
+    for key, value in expected.items():
+        if hasattr(obj, key):
+            assert_equal(getattr(obj, key), value)
+        elif isinstance(obj, dict) and key in obj:
+            assert obj[key] == value
+        else:
+            assert False, f"Not supporting {obj}.{key} == {value}"
+
+
+class MockProblem:
+    path = Path("test/problems/hello")
+
+
+class TestProblemYaml:
+    @pytest.mark.parametrize("testdata", read_tests("valid"))
+    def test_valid(self, testdata):
+        config.n_error = 0
+        config.n_warn = 0
+
+        p = problem.ProblemSettings(testdata["yaml"], MockProblem())
+        assert config.n_error == 0 and config.n_warn == 0, (
+            f"Expected zero errors and warnings, got {config.n_error} and {config.n_warn}"
+        )
+        if "eq" in testdata:
+            assert_equal(p, testdata["eq"])
+
+    @pytest.mark.parametrize("testdata", read_tests("invalid"))
+    def test_invalid(self, monkeypatch, testdata):
+        config.n_error = 0
+        config.n_warn = 0
+
+        fatal = MagicMock(name="fatal")
+        error = MagicMock(name="error")
+        warn = MagicMock(name="warn")
+        monkeypatch.setattr("problem.fatal", fatal)
+        monkeypatch.setattr("problem.error", error)
+        monkeypatch.setattr("problem.warn", warn)
+
+        caught_fatal = False
+        try:
+            problem.ProblemSettings(testdata["yaml"], MockProblem())
+        except SystemExit:
+            caught_fatal = True
+            assert call(testdata["fatal"]) == fatal.mock_calls
+        assert caught_fatal == ("fatal" in testdata)
+
+        assert config.n_error or config.n_warn
+
+        if isinstance(testdata.get("error", None), str):
+            testdata["error"] = [testdata["error"]]
+        assert [call(x) for x in testdata.get("error", [])] == error.mock_calls
+
+        if isinstance(testdata.get("warn", None), str):
+            testdata["warn"] = [testdata["warn"]]
+        assert [call(x) for x in testdata.get("warn", [])] == warn.mock_calls

--- a/test/yaml/problem/invalid.yaml
+++ b/test/yaml/problem/invalid.yaml
@@ -1,5 +1,26 @@
 ---
 yaml:
+  mumbo: jumbo
+warn: "found unknown problem.yaml key: mumbo in root"
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  credits:
+    mumbo: jumbo
+warn: "found unknown problem.yaml key: mumbo in `credits`"
+---
+yaml:
+  limits:
+    mumbo: jumbo
+warn: "found unknown problem.yaml key: mumbo in `limits`"
+---
+yaml:
+  limits:
+    time_multipliers:
+      mumbo: jumbo
+warn: "found unknown problem.yaml key: mumbo in `limits.time_multipliers`"
+---
+yaml:
   name: 42
 warn: incompatible value for key 'name' in problem.yaml. SKIPPED.
 ---

--- a/test/yaml/problem/invalid.yaml
+++ b/test/yaml/problem/invalid.yaml
@@ -1,0 +1,30 @@
+---
+yaml:
+  name: 42
+warn: incompatible value for key 'en' in problem.yaml. SKIPPED.
+---
+yaml:
+  name:
+    en: 42
+warn: incompatible value for key 'en' in problem.yaml. SKIPPED.
+---
+yaml:
+  name:
+    en: "Incorrect validation"
+  validation: mumbo-jumbo
+fatal: Wrong validation
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name:
+    en: "Incorrect type"
+  type: mumbo-jumbo
+fatal: Wrong type
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name:
+    en: "Deprecated validation"
+  validation: interactive
+warn:
+  - "problem.yaml: 'validation' is removed in 2023-07-draft, please use 'type' instead. SKIPPED."

--- a/test/yaml/problem/invalid.yaml
+++ b/test/yaml/problem/invalid.yaml
@@ -1,4 +1,5 @@
 ---
+# Unknown keys
 yaml:
   mumbo: jumbo
 warn: "found unknown problem.yaml key: mumbo in root"
@@ -19,7 +20,9 @@ yaml:
     time_multipliers:
       mumbo: jumbo
 warn: "found unknown problem.yaml key: mumbo in `limits.time_multipliers`"
+
 ---
+# Name
 yaml:
   name: 42
 warn: incompatible value for key 'name' in problem.yaml. SKIPPED.
@@ -28,31 +31,50 @@ yaml:
   name:
     en: 42
 warn: incompatible value for key 'en' in problem.yaml. SKIPPED.
+
 ---
+# Validation/type
 yaml:
-  name:
-    en: "Incorrect validation"
+  name: Incorrect validation
   validation: mumbo-jumbo
 fatal: "problem.yaml: unrecognized validation mode mumbo-jumbo."
 ---
 yaml:
   problem_format_version: 2023-07-draft
-  name:
-    en: "Incorrect type"
+  name: Incorrect type
   type: mumbo-jumbo
 fatal: "problem.yaml: unrecognized value for 'type': mumbo-jumbo"
 ---
 yaml:
   problem_format_version: 2023-07-draft
-  name:
-    en: "Incorrect type"
+  name: Deprecated validation
+  validation: interactive
+warn:
+  - "problem.yaml: 'validation' is removed in 2023-07-draft, please use 'type' instead. SKIPPED."
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Incorrect type
   type: mumbo jumbo
 fatal: "problem.yaml: unrecognized values for 'type': jumbo mumbo"
 ---
 yaml:
   problem_format_version: 2023-07-draft
-  name:
-    en: "Deprecated validation"
-  validation: interactive
-warn:
-  - "problem.yaml: 'validation' is removed in 2023-07-draft, please use 'type' instead. SKIPPED."
+  name: Incorrect type (list)
+  type:
+    - mumbo
+    - jumbo
+fatal: "problem.yaml: unrecognized values for 'type': jumbo mumbo"
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Incorrect type (int)
+  type:
+    mumbo: jumbo
+fatal: "problem.yaml: 'type' must be a string or a sequence"
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Incorrect type (dict)
+  type: 42
+fatal: "problem.yaml: 'type' must be a string or a sequence"

--- a/test/yaml/problem/invalid.yaml
+++ b/test/yaml/problem/invalid.yaml
@@ -1,7 +1,7 @@
 ---
 yaml:
   name: 42
-warn: incompatible value for key 'en' in problem.yaml. SKIPPED.
+warn: incompatible value for key 'name' in problem.yaml. SKIPPED.
 ---
 yaml:
   name:
@@ -12,14 +12,21 @@ yaml:
   name:
     en: "Incorrect validation"
   validation: mumbo-jumbo
-fatal: Wrong validation
+fatal: "problem.yaml: unrecognized validation mode mumbo-jumbo."
 ---
 yaml:
   problem_format_version: 2023-07-draft
   name:
     en: "Incorrect type"
   type: mumbo-jumbo
-fatal: Wrong type
+fatal: "problem.yaml: unrecognized value for 'type': mumbo-jumbo"
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name:
+    en: "Incorrect type"
+  type: mumbo jumbo
+fatal: "problem.yaml: unrecognized values for 'type': jumbo mumbo"
 ---
 yaml:
   problem_format_version: 2023-07-draft

--- a/test/yaml/problem/valid.yaml
+++ b/test/yaml/problem/valid.yaml
@@ -1,4 +1,5 @@
 ---
+# Problem name tests
 yaml:
   name: Minimal
 eq:
@@ -13,14 +14,58 @@ yaml:
   name:
     en: Minimal
     nl: Minimaal
+
 ---
+# Problem validation/type tests
 yaml:
-  name:
-    en: custom validation
+  name: custom validation
   validation: custom
+eq:
+  custom_output: True
+  interactive: False
+  multi_pass: False
 ---
 yaml:
   problem_format_version: 2023-07-draft
-  name:
-    en: pass-fail type
+  name: pass-fail type
   type: pass-fail
+eq:
+  custom_output: False
+  interactive: False
+  multi_pass: False
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: interactive type
+  type: interactive
+eq:
+  custom_output: True
+  interactive: True
+  multi_pass: False
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: multi-pass type
+  type: multi-pass
+eq:
+  custom_output: True
+  interactive: False
+  multi_pass: True
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: interactive multi-pass type
+  type: interactive multi-pass
+eq:
+  custom_output: True
+  interactive: True
+  multi_pass: True
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: multi-pass interactive type
+  type: multi-pass interactive
+eq:
+  custom_output: True
+  interactive: True
+  multi_pass: True

--- a/test/yaml/problem/valid.yaml
+++ b/test/yaml/problem/valid.yaml
@@ -36,6 +36,23 @@ eq:
 ---
 yaml:
   problem_format_version: 2023-07-draft
+  name: pass-fail type by default
+eq:
+  custom_output: False
+  interactive: False
+  multi_pass: False
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: pass-fail type from empty type
+  type: []
+eq:
+  custom_output: False
+  interactive: False
+  multi_pass: False
+---
+yaml:
+  problem_format_version: 2023-07-draft
   name: interactive type
   type: interactive
 eq:

--- a/test/yaml/problem/valid.yaml
+++ b/test/yaml/problem/valid.yaml
@@ -69,3 +69,68 @@ eq:
   custom_output: True
   interactive: True
   multi_pass: True
+
+---
+# Credits tests
+yaml:
+  author: A. U. Thor
+eq:
+  credits:
+    authors:
+      - name: A. U. Thor
+        email: ~
+---
+yaml:
+  author: A. U. Thor <author@example.com>
+eq:
+  credits:
+    authors:
+      - name: A. U. Thor
+        email: author@example.com
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  credits: A. U. Thor
+eq:
+  credits:
+    authors:
+      - name: A. U. Thor
+        email: ~
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  credits: A. U. Thor <author@example.com>
+eq:
+  credits:
+    authors:
+      - name: A. U. Thor
+        email: author@example.com
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  credits: A. U. Thor <author@example.com>
+eq:
+  credits:
+    authors:
+      - name: A. U. Thor
+        email: author@example.com
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  credits:
+    authors: A. U. Thor <author@example.com>
+    translators:
+      nl: V. E. R. Taler
+      en: T. R. Anslator <translator@example.com>
+eq:
+  credits:
+    authors:
+      - name: A. U. Thor
+        email: author@example.com
+    translators:
+      nl:
+        - name: V. E. R. Taler
+          email: ~
+      en:
+        - name: T. R. Anslator
+          email: translator@example.com

--- a/test/yaml/problem/valid.yaml
+++ b/test/yaml/problem/valid.yaml
@@ -1,0 +1,26 @@
+---
+yaml:
+  name: Minimal
+eq:
+  name:
+    en: Minimal
+---
+yaml:
+  name:
+    en: Minimal
+---
+yaml:
+  name:
+    en: Minimal
+    nl: Minimaal
+---
+yaml:
+  name:
+    en: custom validation
+  validation: custom
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name:
+    en: pass-fail type
+  type: pass-fail


### PR DESCRIPTION
Since we were already well underway supporting the new features of https://icpc.io/problem-package-format/spec/2023-07-draft.html#problem-metadata, this PR aims to finishes it. I've also set up a test-bench for validating whether `problem.yaml` files are correctly accepted or rejected (along with any expected warnings/errors/fatals). Still to-do in the future (not for this PR):

- [ ] Read `validator_flags` only from `testdata.yaml` for the new spec
	- Keep supporting it for legacy problems
	- Also revert back to `validator_flags` for the DOMjudge export... :smiling_face_with_tear: 
- [ ] Add more tests

In theory, both these points can also be picked up in later PRs to keep the reviews manageable, so feedback is welcome already :smile: Specifically, please check whether all fields for both `legacy` and `2023-07-draft` now have a one-to-one mapping between the specification and the `ProblemSettings` initializer. I've tried to keep the order of parsing as close as possible to the order in the spec :slightly_smiling_face: 