### PR TITLE
More consistent floating-point parsing in validators

### DIFF
--- a/headers/validation.h
+++ b/headers/validation.h
@@ -38,11 +38,11 @@
 #include <variant>
 #include <vector>
 
-const std::string_view case_sensitive_flag       = "case_sensitive";
-const std::string_view ws_sensitive_flag         = "space_change_sensitive";
-const std::string_view constraints_file_flag     = "--constraints_file";
-const std::string_view generate_flag             = "--generate";
-const std::string_view generate_binary_substring = "generat";
+constexpr std::string_view case_sensitive_flag       = "case_sensitive";
+constexpr std::string_view ws_sensitive_flag         = "space_change_sensitive";
+constexpr std::string_view constraints_file_flag     = "--constraints_file";
+constexpr std::string_view generate_flag             = "--generate";
+constexpr std::string_view generate_binary_substring = "generat";
 
 // Only use non-capturing groups, and optimize the RegEx during initialization (improves run time at the cost of build time)
 constexpr auto regex_options = std::regex::nosubs | std::regex::optimize;
@@ -52,7 +52,7 @@ constexpr auto regex_options = std::regex::nosubs | std::regex::optimize;
 // - Disallowing 'E' as exponent
 // - Disallowing superfluous leading zeroes before the decimal dot and in the exponent (the former can be 0, the latter cannot)
 // - Disallowing decimal dot without following digits
-std::regex float_regex("-?(0|[1-9][0-9]*)(\\.[0-9]+)?(e-?[1-9][0-9]*)?", regex_options);
+const std::regex float_regex("-?(0|[1-9][0-9]*)(\\.[0-9]+)?(e-?[1-9][0-9]*)?", regex_options);
 
 inline struct ArbitraryTag {
 	static constexpr bool unique     = false;

--- a/support/default_output_validator.cpp
+++ b/support/default_output_validator.cpp
@@ -6,8 +6,8 @@
 #include <fstream>
 #include <iostream>
 #include <optional>
-#include <sstream>
 #include <regex>
+#include <sstream>
 #include <string>
 
 //============================================================================//
@@ -27,7 +27,7 @@ constexpr std::string_view WHITESPACE               = " \f\n\r\t\v";
 // Only use non-capturing groups, and optimize the RegEx during initialization (improves run time at the cost of build time)
 constexpr auto REGEX_OPTIONS = std::regex::nosubs | std::regex::optimize;
 // Source: https://icpc.io/problem-package-format/spec/2023-07-draft.html
-std::regex FLOAT_REGEX("[+-]?([0-9]*\\.[0-9]+|[0-9]+\\.|[0-9]+)([Ee][+-]?[0-9]+)?", REGEX_OPTIONS);
+const std::regex FLOAT_REGEX("[+-]?([0-9]*\\.[0-9]+|[0-9]+\\.|[0-9]+)([Ee][+-]?[0-9]+)?", REGEX_OPTIONS);
 
 //============================================================================//
 // parameters                                                                 //


### PR DESCRIPTION
Follow-up of https://github.com/RagnarGrootKoerkamp/BAPCtools/pull/420#discussion_r1961484595. The outcome of this discussion is that input and answer files should look "clean". We already enforce case- and whitespace-sensitivity for `*.in` and `*.ans` files in `validation.h`, and this PR adds strict floating-point parsing to this.

Note that output validation does not use the strict floating-points, because from submissions, we want to accept any valid floating-point number (as defined in [the spec](https://icpc.io/problem-package-format/spec/2023-07-draft.html#general-requirements)), regardless of how ugly it looks :stuck_out_tongue: 
- In `validation.h`, we accept any floating-point number that is accepted by `stold` for `OutputValidator` by passing `strict_float=false` to the `Validator` super-constructor. I don't think we need to add a flag to enable stricter floating-point parsing for custom output validators.
- In `default_output_validator.cpp`, the `util::is_float` function now checks against the RegEx based on the grammar from the spec. 
  - Note that this validator is only used when running BAPCtools and not during a contest, because there are different "default output validators" in [DOMjudge](https://github.com/DOMjudge/domjudge/blob/main/sql/files/defaultdata/compare/compare.cc) and [Kattis](https://github.com/Kattis/problemtools/blob/develop/support/default_validator/default_validator.cc).

I've tested this on Kruidnoten from NWERC 2024 (which has floating-point answers), and the warnings in `bt validate --generic-invalid` are now gone :smile: