### PR TITLE
[problem] Update parsing of problem.yaml based on Kattis/problem-package-format#372

### DIFF
--- a/bin/problem.py
+++ b/bin/problem.py
@@ -134,31 +134,48 @@ class ProblemLimits:
         time_multipliers = parse_setting(yaml_data, "time_multipliers", dict[str, Any]())
 
         parse_deprecated_setting(yaml_data, "time_multiplier", "ac_to_time_limit")
-        self.ac_to_time_limit = parse_setting(time_multipliers, "ac_to_time_limit", 2.0)
+        self.ac_to_time_limit = parse_setting(time_multipliers, "ac_to_time_limit", 2.0, ">= 1")
         parse_deprecated_setting(yaml_data, "time_safety_margin", "time_limit_to_tle")
-        self.time_limit_to_tle = parse_setting(time_multipliers, "time_limit_to_tle", 1.5)
+        self.time_limit_to_tle = parse_setting(time_multipliers, "time_limit_to_tle", 1.5, ">= 1")
 
         check_unknown_keys(time_multipliers, "limits.time_multipliers")
 
-        time_limit = parse_optional_setting(yaml_data, "time_limit", float)  # in seconds
-        self.time_resolution: float = parse_setting(yaml_data, "time_resolution", 1.0)
-        self.memory: int = parse_setting(yaml_data, "memory", 2048)  # in MiB
-        self.output: int = parse_setting(yaml_data, "output", 8)  # in MiB
-        self.code: int = parse_setting(yaml_data, "code", 128)  # in KiB
-        self.compilation_time: int = parse_setting(yaml_data, "compilation_time", 60)  # in seconds
+        self.time_limit_is_default: bool = "time_limit" not in yaml_data
+        self.time_limit: float = parse_setting(yaml_data, "time_limit", 1.0, "> 0")  # in seconds
+        self.time_resolution: float = parse_setting(yaml_data, "time_resolution", 1.0, "> 0")
+        self.memory: int = parse_setting(yaml_data, "memory", 2048, "> 0")  # in MiB
+        self.output: int = parse_setting(yaml_data, "output", 8, "> 0")  # in MiB
+        self.code: int = parse_setting(yaml_data, "code", 128, "> 0")  # in KiB
+        self.compilation_time: int = parse_setting(
+            yaml_data, "compilation_time", 60, "> 0"
+        )  # in seconds
         self.compilation_memory: int = parse_setting(
-            yaml_data, "compilation_memory", 2048
+            yaml_data, "compilation_memory", 2048, "> 0"
         )  # in MiB
-        self.validation_time: int = parse_setting(yaml_data, "validation_time", 60)  # in seconds
-        self.validation_memory: int = parse_setting(yaml_data, "validation_memory", 2048)  # in MiB
-        self.validation_output: int = parse_setting(yaml_data, "validation_output", 8)  # in MiB
-        self.validation_passes: Optional[int] = parse_optional_setting(
-            yaml_data, "validation_passes", int
-        )
+        self.validation_time: int = parse_setting(
+            yaml_data, "validation_time", 60, "> 0"
+        )  # in seconds
+        self.validation_memory: int = parse_setting(
+            yaml_data, "validation_memory", 2048, "> 0"
+        )  # in MiB
+        self.validation_output: int = parse_setting(
+            yaml_data, "validation_output", 8, "> 0"
+        )  # in MiB
+        if problem_settings.multi_pass:
+            self.validation_passes: Optional[int] = parse_setting(
+                yaml_data, "validation_passes", 2, ">= 2"
+            )
+        elif "validation_passes" in yaml_data:
+            yaml_data.pop("validation_passes")
+            warn("limit: validation_passes is only used for multi-pass problems. SKIPPED.")
 
         # BAPCtools extensions:
-        self.generator_time: int = parse_setting(yaml_data, "generator_time", 60)  # in seconds
-        self.visualizer_time: int = parse_setting(yaml_data, "visualizer_time", 60)  # in seconds
+        self.generator_time: int = parse_setting(
+            yaml_data, "generator_time", 60, "> 0"
+        )  # in seconds
+        self.visualizer_time: int = parse_setting(
+            yaml_data, "visualizer_time", 60, "> 0"
+        )  # in seconds
 
         # warn for deprecated timelimit files
         if (problem.path / ".timelimit").is_file():
@@ -167,9 +184,6 @@ class ProblemLimits:
             warn(
                 "domjudge-problem.ini is DEPRECATED. Use limits.time_limit if you want to set a timelimit."
             )
-
-        self.time_limit: float = time_limit or 1.0
-        self.time_limit_is_default: bool = time_limit is None
 
         check_unknown_keys(yaml_data, "limits")
 
@@ -244,7 +258,7 @@ class ProblemSettings:
             yaml_data, "validator_flags", "output_validator_args' in 'testdata.yaml"
         )
 
-        self.keywords: str = parse_setting(yaml_data, "keywords", "")
+        self.keywords: list[str] = parse_optional_list_setting(yaml_data, "keywords", str)
         # Not implemented in BAPCtools. We always test all languges in langauges.yaml.
         self.languages: list[str] = parse_optional_list_setting(yaml_data, "languages", str)
 
@@ -270,13 +284,6 @@ class ProblemSettings:
         if self.license not in config.KNOWN_LICENSES:
             warn(f"invalid license: {self.license}")
             self.license = "unknown"
-
-        # Check that limits.validation_passes exists if and only if the problem is multi-pass
-        has_validation_passes = self.limits.validation_passes is not None
-        if self.multi_pass and not has_validation_passes:
-            self.limits.validation_passes = 2
-        if not self.multi_pass and has_validation_passes:
-            warn("limit: validation_passes is only used for multi_pass problems. SKIPPED.")
 
 
 # A problem.

--- a/bin/util.py
+++ b/bin/util.py
@@ -813,9 +813,15 @@ def parse_optional_setting(yaml_data: dict[str, Any], key: str, t: type[T]) -> O
     return None
 
 
-def parse_setting(yaml_data: dict[str, Any], key: str, default: T) -> T:
+def parse_setting(
+    yaml_data: dict[str, Any], key: str, default: T, constraint: Optional[str] = None
+) -> T:
     value = parse_optional_setting(yaml_data, key, type(default))
-    return default if value is None else value
+    result = default if value is None else value
+    if constraint and not eval(f"{result} {constraint}"):
+        warn(f"value for '{key}' in problem.yaml should be {constraint} but is {value}. SKIPPED.")
+        return default
+    return result
 
 
 def parse_optional_list_setting(yaml_data: dict[str, Any], key: str, t: type[T]) -> list[T]:
@@ -829,6 +835,8 @@ def parse_optional_list_setting(yaml_data: dict[str, Any], key: str, t: type[T])
                     f"some values for key '{key}' in problem.yaml do not have type {t.__name__}. SKIPPED."
                 )
                 return []
+            if not value:
+                warn(f"value for '{key}' in problem.yaml should not be an empty list.")
             return value
         warn(f"incompatible value for key '{key}' in problem.yaml. SKIPPED.")
     return []

--- a/test/yaml/problem/invalid.yaml
+++ b/test/yaml/problem/invalid.yaml
@@ -25,6 +25,20 @@ yaml:
 warn: "found unknown problem.yaml key: mumbo in `limits.time_multipliers`"
 
 ---
+# UUID
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Invalid UUID, too short
+  uuid: 12345678-abcd
+warn: "invalid uuid: 12345678-abcd"
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Invalid UUID, not hexadecimal
+  uuid: 12345678-abcd-efgh-ijkl-12345678
+warn: "invalid uuid: 12345678-abcd-efgh-ijkl-12345678"
+
+---
 # Name
 yaml:
   problem_format_version: 2023-07-draft
@@ -139,3 +153,37 @@ yaml:
   name: Empty list
   keywords: []
 warn: "value for 'keywords' in problem.yaml should not be an empty list."
+
+---
+# Credits
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Cannot specify multiple authors in credits
+  credits:
+    - name: Alice
+    - name: Audrey Authorson
+      email: bob@foo.bar
+warn: "incompatible value for key 'credits' in problem.yaml. SKIPPED."
+
+---
+# Source
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Source must have a name
+  source:
+    - url: https://2024.nwerc.example/contest
+warn: "problem.yaml: 'name' is required in source"
+
+---
+# Embargo
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Embargo is not a date
+  embargo_until: not a date
+warn: "incompatible value for key 'embargo_until' in problem.yaml. SKIPPED."
+#---
+#yaml:
+#  problem_format_version: 2023-07-draft
+#  name: Embargo date does not exist
+#  embargo_until: 2025-02-29
+# Note that this cannot be tested in this way, because the YAML parser already throws an error.

--- a/test/yaml/problem/invalid.yaml
+++ b/test/yaml/problem/invalid.yaml
@@ -85,3 +85,57 @@ yaml:
   name: Incorrect type (dict)
   type: 42
 fatal: "problem.yaml: 'type' must be a string or a sequence"
+
+---
+# Limits
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Negative time limit
+  limits:
+    time_limit: -1
+warn: "value for 'time_limit' in problem.yaml should be > 0 but is -1.0. SKIPPED."
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Time multiplier < 1
+  limits:
+    time_multipliers:
+      ac_to_time_limit: 0.9
+warn: "value for 'ac_to_time_limit' in problem.yaml should be >= 1 but is 0.9. SKIPPED."
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Only one pass for multi-pass
+  type: multi-pass
+  limits:
+    validation_passes: 1
+warn: "value for 'validation_passes' in problem.yaml should be >= 2 but is 1. SKIPPED."
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Fractional passes for multi-pass
+  type: multi-pass
+  limits:
+    validation_passes: 2.5
+warn: "incompatible value for key 'validation_passes' in problem.yaml. SKIPPED."
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: validation_passes for non-multi-pass problem
+  limits:
+    validation_passes: 3
+warn: "limit: validation_passes is only used for multi-pass problems. SKIPPED."
+
+---
+# Empty list
+yaml:
+  problem_format_version: 2023-07-draft
+  name: pass-fail type from empty type
+  type: []
+warn: "value for 'type' in problem.yaml should not be an empty list."
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Empty list
+  keywords: []
+warn: "value for 'keywords' in problem.yaml should not be an empty list."

--- a/test/yaml/problem/valid.yaml
+++ b/test/yaml/problem/valid.yaml
@@ -18,6 +18,15 @@ yaml:
   name:
     en: Minimal
     nl: Minimaal
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name:
+    en: Hello World!
+    pt-BR: Olá mundo!
+    pt-PT: Oi mundo!
+    fil: Kumusta mundo!
+    gsw-u-sd-chzh: Sali Zämme, Wäut!
 
 ---
 # Problem type tests
@@ -122,3 +131,96 @@ eq:
       en:
         - name: T. R. Anslator
           email: translator@example.com
+
+---
+# Source tests
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Source can be just a string
+  source: NWERC 2024
+eq:
+  source:
+    - name: NWERC 2024
+      url: ~
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Source can be map
+  source:
+    name: NWERC 2024
+eq:
+  source:
+    - name: NWERC 2024
+      url: ~
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Source can be map with two keys (name, url)
+  source:
+    name: NWERC 2024
+    url: https://2024.nwerc.example/contest
+eq:
+  source:
+    - name: NWERC 2024
+      url: https://2024.nwerc.example/contest
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Many sources can be specified
+  source:
+    - name: NWERC 2024
+      url: https://2024.nwerc.example/contest
+    - SWERC 2024
+    - name: SEERC 2024
+eq:
+  source:
+    - name: NWERC 2024
+      url: https://2024.nwerc.example/contest
+    - name: SWERC 2024
+      url: ~
+    - name: SEERC 2024
+      url: ~
+
+---
+# License tests
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Rights-less license
+  license: public domain
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Specify license and rights owner
+  license: cc0
+  rights_owner: Bob
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Don't need license if credits are given
+  license: cc0
+  credits: Bob
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Don't need license if credits.authors are given
+  license: cc0
+  credits:
+    authors: "Bob"
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Don't need license if source is given
+  license: cc0
+  source: NWERC 2024
+
+---
+# Embargo tests
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Embargo date
+  embargo_until: 2025-12-31
+---
+yaml:
+  problem_format_version: 2023-07-draft
+  name: Embargo datetime
+  embargo_until: 2025-12-31T23:59:59

--- a/test/yaml/problem/valid.yaml
+++ b/test/yaml/problem/valid.yaml
@@ -40,15 +40,6 @@ eq:
 ---
 yaml:
   problem_format_version: 2023-07-draft
-  name: pass-fail type from empty type
-  type: []
-eq:
-  custom_output: False
-  interactive: False
-  multi_pass: False
----
-yaml:
-  problem_format_version: 2023-07-draft
   name: interactive type
   type: interactive
 eq:


### PR DESCRIPTION
See Kattis/problem-package-format#372.

Changes:
- **C1**: Keywords are now a list of strings (we used to still parse them as a single string, woops)
- **C2**: No change needed, this was just a "bug" in the human-readable text of the specification
- **C3**: Add constraints to float/int types in `limits` and warnings when any of the values are out of range
- **C5**: Do not allow lists to be empty (if a list-field is optional, it should be either `None` or a non-empty list)

The discussion for **C4** was moved to https://github.com/Kattis/problem-package-format/issues/378 and is pending consensus, and the proposals for **C6**, **Q1**, and **Q2** were dropped.