### PR TITLE
Use new visualizers structure from 2023-07-draft

### DIFF
--- a/bin/problem.py
+++ b/bin/problem.py
@@ -912,6 +912,13 @@ class Problem:
                 paths = [problem.path / validate.OutputValidator.source_dir]
             else:
                 paths = [config.TOOLS_ROOT / "support" / "default_output_validator.cpp"]
+        elif cls == validate.OutputVisualizer:
+            # TODO: if not config.args.no_output_visualizer:
+            paths = (
+                [problem.path / validate.OutputVisualizer.source_dir]
+                if (problem.path / validate.OutputVisualizer.source_dir).is_dir()
+                else []
+            )
         else:
             paths = list(glob(problem.path / cls.source_dir, "*"))
 
@@ -946,7 +953,7 @@ class Problem:
             )
             for path in paths
         ]
-        bar = ProgressBar(f"Building {cls.validator_type} validator", items=validators)
+        bar = ProgressBar(f"Building {cls.validator_type}", items=validators)
 
         def build_program(p):
             localbar = bar.start(p)
@@ -965,9 +972,10 @@ class Problem:
         if not testcases:
             return False
 
-        # Pre build the output validator to prevent nested ProgressBars.
+        # Pre build the output validator and visualizer to prevent nested ProgressBars.
         if not problem.validators(validate.OutputValidator):
             return False
+        problem.validators(validate.OutputVisualizer)
 
         submissions = problem.submissions()
         if not submissions:

--- a/bin/program.py
+++ b/bin/program.py
@@ -604,10 +604,11 @@ class Visualizer(Program):
         )
 
     # Run the visualizer.
-    # Stdin and stdout are not used.
-    def run(self, cwd, args=[]):
+    # Stdout is not used.
+    def run(self, cwd, stdin, args=[]):
         assert self.run_command is not None
         return self._exec_command(
             self.run_command + args,
             cwd=cwd,
+            stdin=stdin,
         )

--- a/bin/run.py
+++ b/bin/run.py
@@ -5,7 +5,7 @@ import sys
 
 from colorama import Fore, Style
 from pathlib import Path
-from typing import cast
+from typing import Optional, cast
 
 import config
 import interactive
@@ -174,7 +174,9 @@ class Run:
 
             result.duration = max_duration
 
-            # Delete .out files larger than 1MB.
+            self._visualize_output(bar)
+
+            # Delete .out files larger than 1GB.
             if (
                 not config.args.error
                 and self.out_path.is_file()
@@ -215,7 +217,7 @@ class Run:
         shutil.move(nextpass, self.in_path)
         return True
 
-    def _validate_output(self, bar):
+    def _validate_output(self, bar: ProgressBar) -> Optional[ExecResult]:
         output_validators = self.problem.validators(validate.OutputValidator)
         if not output_validators:
             return None
@@ -225,6 +227,16 @@ class Run:
             self.testcase,
             self,
             args=self.testcase.testdata_yaml_validator_args(output_validator, bar),
+        )
+
+    def _visualize_output(self, bar: ProgressBar) -> Optional[ExecResult]:
+        output_validators = self.problem.validators(validate.OutputVisualizer)
+        if not output_validators:
+            return None
+        return output_validators[0].run(
+            self.testcase,
+            self,
+            args=self.testcase.testdata_yaml_validator_args(output_validators[0], bar),
         )
 
 


### PR DESCRIPTION
The input visualizers were quite simple to change, the only change required was that the input visualizers now read the test case from stdin, rather than `testcase.in`.

The output visualizers are currently a special type of output validator, because they share a lot (mostly, in the way how they are executed). This feels very ugly, but I just wanted to get some working implementation up and running to aid in the discussion in https://github.com/Kattis/problem-package-format/issues/351 :slightly_smiling_face: 

TODO:
- [ ] Allow disabling output visualizers with a command-line argument `--no-output-visualizer` (probably `--no-visualizer` needs to be renamed to `--no-input-visualizer` as well)
- [ ] `bt upgrade` needs to read `generators.yaml`, and if it has a `visualizer:` key, move the target to `input_visualizer/` and remove it from `generators.yaml`. It should then warn that the visualizer itself needs to be rewritten to no longer read from `testcase.in`, but from stdin.
- [ ] The resulting `judgeimage.<ext>` of the output visualizer can be copied back to `data/` when `bt generate` runs it on the canonical jury solution, but only when there is no input visualizer, because there can be at most one image per test case.
- [ ] Related to the above: should we do something when any input _validator_ happens to write image files?
- [ ] Related to the above: should we do something when the output _validator_ happens to write image files?
- [ ] I haven't tested this with interactive and multi-pass problems.

I've currently tested this with a `bt upgrade`d version of NWERC 2024 Jib Job, to which I've added a simple `output_visualizer/`: [jibjob.zip](https://github.com/user-attachments/files/19271681/jibjob.zip)