### PR TITLE
[skel/problem_cfp] move spoilers into a separate `.md` file

### DIFF
--- a/skel/problem_cfp/README.md
+++ b/skel/problem_cfp/README.md
@@ -4,15 +4,3 @@ Print the perimeter of a square with a given area $a$.
 
 NOTE: Please put possible variants of the problem in the problem statement
 itself.
-
-## Solution and analysis:
-
-A square with area $a$ has a side length of $\sqrt a$. A square has 4 sides so
-the total perimeter is $4\sqrt a$.
-
-One potential issue is that teams might not print sufficiently many digits.
-
-
-## Difficulty:
-(0%: everybody solves the problem, 99%: 1 team solves the problem)
-5%: I think that 5% of BAPC teams will *not* solve this.

--- a/skel/problem_cfp/SOLUTION.md
+++ b/skel/problem_cfp/SOLUTION.md
@@ -1,0 +1,10 @@
+# Solution and analysis:
+
+A square with area $a$ has a side length of $\sqrt a$. A square has 4 sides so
+the total perimeter is $4\sqrt a$.
+
+One potential issue is that teams might not print sufficiently many digits.
+
+# Difficulty:
+(0%: everybody solves the problem, 99%: 1 team solves the problem)
+5%: I think that 5% of NWERC teams will *not* solve this.

--- a/skel/problem_cfp/SOLUTION.md
+++ b/skel/problem_cfp/SOLUTION.md
@@ -1,10 +1,10 @@
+# Difficulty:
+(0%: everybody solves the problem, 99%: 1 team solves the problem)
+5%: I think that 5% of NWERC teams will *not* solve this.
+
 # Solution and analysis:
 
 A square with area $a$ has a side length of $\sqrt a$. A square has 4 sides so
 the total perimeter is $4\sqrt a$.
 
 One potential issue is that teams might not print sufficiently many digits.
-
-# Difficulty:
-(0%: everybody solves the problem, 99%: 1 team solves the problem)
-5%: I think that 5% of NWERC teams will *not* solve this.


### PR DESCRIPTION
For purposes of a Call for Problems it's nice to have all the information about the intended solution of the problem in a separate file (i.e. not in the `README.md`). The same goes for the author's difficulty estimate.

Having this information outside of the `README.md` also means that it does not get automatically shown to you if you browse the contest problems in the GitHub/GitLab web interface.