### PR TITLE
Fix missing tuple wrapper in RESERVED_DIRECTORY_KEYS

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -342,7 +342,7 @@ KNOWN_DIRECTORY_KEYS: Final[Sequence[str]] = (
     "random_salt",
     "retries",
 )
-RESERVED_DIRECTORY_KEYS: Final[Sequence[str]] = "command"
+RESERVED_DIRECTORY_KEYS: Final[Sequence[str]] = ("command",)
 KNOWN_ROOT_KEYS: Final[Sequence[str]] = ("generators", "parallel", "version")
 DEPRECATED_ROOT_KEYS: Final[Sequence[str]] = ("gitignore_generated", "visualizer")
 


### PR DESCRIPTION
I just saw this while rebasing, this seems to have slipped through in a81d4fbda22571b658581392bddb8aaa00bf2594.
