### PR TITLE
Fix "could not parse contest.yaml" error when no file exists

### DIFF
--- a/bin/contest.py
+++ b/bin/contest.py
@@ -128,12 +128,13 @@ def contest_yaml() -> ContestYaml:
     if _contest_yaml is not None:
         return _contest_yaml
 
-    raw_yaml = None
     contest_yaml_path = Path("contest.yaml")
     if contest_yaml_path.is_file():
         raw_yaml = read_yaml(contest_yaml_path)
         if not isinstance(raw_yaml, dict):
             fatal("could not parse contest.yaml, must be a dict.")
+    else:
+        raw_yaml = None
 
     _contest_yaml = ContestYaml(raw_yaml)
     return _contest_yaml


### PR DESCRIPTION
I was trying to test my branch and noticed that this error is thrown. From the type hints of `ContestYaml.__init__` and the code that was replaced in f7f25b1589a32a38e20e3abef32497d5cfe7903f, I suspect that this is the desired behavior?
