### PR TITLE
chore(docker): add texlive-langextra for indonesian language support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pacman -Syu --noconfirm \
 	texlive-binextra \
 	texlive-langeuropean \
 	texlive-langgerman \
+	texlive-langextra \
 	texlive-latexextra \
 	texlive-pictures \
 	texlive-science \


### PR DESCRIPTION
Related to #512, `texlive-langextra` package is needed for the indonesian language for `bt pdf` command. This PR adds it to the Dockerfile.

I saw that #511 also did some modification to the Dockerfile, but it seems orthogonal to this PR.