### PR TITLE
[validation.h] Fix CountIterator interface

### DIFF
--- a/bapctools/resources/headers/compile_flags.txt
+++ b/bapctools/resources/headers/compile_flags.txt
@@ -1,3 +1,3 @@
--std=c++20
+-std=c++17
 -Wall
 -Werror

--- a/bapctools/resources/headers/validation.h
+++ b/bapctools/resources/headers/validation.h
@@ -759,12 +759,16 @@ class Validator {
 					} while(!seen_here.insert(v).second);
 
 					struct CountIterator {
+						using value_type = T;
+						using difference_type = std::ptrdiff_t;
+
 						T v;
-						T& operator*() { return v; }
-						T& operator++() { return ++v; }
-						T operator++(int) { return v++; }
-						bool operator!=(CountIterator r) { return v != r.v; }
+						value_type operator*() const { return v; }
+						CountIterator& operator++() { ++v; return *this; }
+						CountIterator operator++(int) { return { v++ }; }
+						bool operator==(CountIterator r) const { return v == r.v; }
 					};
+					static_assert(std::forward_iterator<CountIterator>);
 
 					if(seen_here.size() > (high - low) / 2) {
 						use_remaining = true;

--- a/bapctools/resources/headers/validation.h
+++ b/bapctools/resources/headers/validation.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <optional>
@@ -759,16 +760,22 @@ class Validator {
 					} while(!seen_here.insert(v).second);
 
 					struct CountIterator {
-						using value_type = T;
 						using difference_type = std::ptrdiff_t;
+						using value_type = T;
+						using pointer = value_type*;
+						// C++17: must be reference to value_type for LegacyForwardIterator, but we are only a LegacyInputIterator
+						// C++20: fine, even for the std::forward_iterator concept
+						using reference = value_type;
+						using iterator_category = std::input_iterator_tag;
 
-						T v;
-						value_type operator*() const { return v; }
+						T v{};
+						reference operator*() const { return v; }
 						CountIterator& operator++() { ++v; return *this; }
-						CountIterator operator++(int) { return { v++ }; }
-						bool operator==(CountIterator r) const { return v == r.v; }
+						CountIterator operator++(int) { auto copy = *this; ++(*this); return copy; }
+
+						bool operator==(const CountIterator& r) const { return v == r.v; }
+						bool operator!=(const CountIterator& r) const { return v != r.v; }
 					};
-					static_assert(std::forward_iterator<CountIterator>);
 
 					if(seen_here.size() > (high - low) / 2) {
 						use_remaining = true;


### PR DESCRIPTION
Before this change, the following line in an input validator

```cpp
v.read_integer("x", 0, 42, Unique);
```

would yield a compilation error

```plain
<snip>/include/c++/14.3.0/bits/stl_algobase.h:514:64: error: no type named ‘iterator_category’ in ‘struct std::iterator_traits<Validator::gen_number<long long int, UniqueTag>(const std::string&, long long int, long long int, UniqueTag)::CountIterator>’
  514 |       typedef typename iterator_traits<_II>::iterator_category _Category;
```

The definition of CountIterator has multiple problems:
1. It does not declare the type aliases required for any of the iterator
   concepts.
2. When incrementing, it should return another iterator, not a value.
   This probably worked coincidentally because the number can be
   converted back to an iterator immediately
3. Dereference and comparison were non-const only.