### PR TITLE
Feat/macostest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,33 @@ jobs:
       - run: bash test/yaml/validate_yaml.sh
       - run: pytest
 
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - run: brew install kotlin
+      - run: brew install --cask basictex
+      - run: |
+          export PATH="/Library/TeX/texbin:$PATH"
+          sudo tlmgr update --self
+          sudo tlmgr install \
+            latexmk lm \
+            collection-latexrecommended collection-latexextra \
+            collection-science \
+            babel-german hyphen-german \
+            asymptote
+      - run: pip install --editable . --group dev
+      - run: |
+          export PATH="/Library/TeX/texbin:$PATH"
+          pytest
+
   test-wsl:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,33 +25,6 @@ jobs:
       - run: bash test/yaml/validate_yaml.sh
       - run: pytest
 
-  test-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-      - run: brew install kotlin
-      - run: brew install --cask basictex
-      - run: |
-          export PATH="/Library/TeX/texbin:$PATH"
-          sudo tlmgr update --self
-          sudo tlmgr install \
-            latexmk lm \
-            collection-latexrecommended collection-latexextra \
-            collection-science \
-            babel-german hyphen-german \
-            asymptote
-      - run: pip install --editable . --group dev
-      - run: |
-          export PATH="/Library/TeX/texbin:$PATH"
-          pytest
-
   test-wsl:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,15 @@ jobs:
           sudo tlmgr update --self
           sudo tlmgr install \
             latexmk lm \
-            collection-latexrecommended collection-latexextra \
-            collection-science \
-            babel-german hyphen-german \
-            asymptote
+            collection-latexrecommended \
+            algorithms algorithmicx animate cancel courier \
+            enumitem environ eqparbox etoolbox \
+            frcursive hyphenat jknapltx \
+            listingsutf8 pgf pgfplots \
+            setspace siunitx standalone subcaption \
+            tcolorbox tikz-qtree tocloft upquote wrapfig \
+            xparse \
+            babel-german hyphen-german
       - run: pip install --editable . --group dev
       - run: |
           export PATH="/Library/TeX/texbin:$PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,15 +43,10 @@ jobs:
           sudo tlmgr update --self
           sudo tlmgr install \
             latexmk lm \
-            collection-latexrecommended \
-            algorithms algorithmicx animate cancel courier \
-            enumitem environ eqparbox etoolbox \
-            frcursive hyphenat jknapltx \
-            listingsutf8 pgf pgfplots \
-            setspace siunitx standalone subcaption \
-            tcolorbox tikz-qtree tocloft upquote wrapfig \
-            xparse \
-            babel-german hyphen-german
+            collection-latexrecommended collection-latexextra \
+            collection-science \
+            babel-german hyphen-german \
+            asymptote
       - run: pip install --editable . --group dev
       - run: |
           export PATH="/Library/TeX/texbin:$PATH"

--- a/bapctools/cli.py
+++ b/bapctools/cli.py
@@ -116,7 +116,7 @@ def change_directory() -> Optional[Path]:
 def get_problems(problem_dir: Optional[Path]) -> tuple[list[Problem], Path]:
     # We create one tmpdir per contest.
     h = hashlib.sha256(bytes(Path.cwd())).hexdigest()[-6:]
-    tmpdir = Path(tempfile.gettempdir()) / ("bapctools_" + h)
+    tmpdir = (Path(tempfile.gettempdir()) / ("bapctools_" + h)).resolve()
     tmpdir.mkdir(parents=True, exist_ok=True)
 
     def fallback_problems() -> list[tuple[Path, str]]:

--- a/bapctools/config.py
+++ b/bapctools/config.py
@@ -300,7 +300,7 @@ args = ARGS("config.py")
 
 
 @contextmanager
-def temporary_args() -> Generator[None]:
+def temporary_args() -> Generator[None, None, None]:
     assert threading.current_thread() is threading.main_thread()
     old_args = args.copy()
     try:
@@ -313,7 +313,7 @@ def temporary_args() -> Generator[None]:
 # suppresses warning messages as well as setting n_warn
 # if level == 2, this does also suppress errors
 @contextmanager
-def suppress_warnings(level: int = 1) -> Generator[None]:
+def suppress_warnings(level: int = 1) -> Generator[None, None, None]:
     assert threading.current_thread() is threading.main_thread()
     old_suppress_warnings = args.suppress_warnings
     args.suppress_warnings = level

--- a/bapctools/generate.py
+++ b/bapctools/generate.py
@@ -699,6 +699,7 @@ class TestcaseRule(Rule):
                                 )
                             value = value["link"]
                             assert_type(f"{key}.link", value, str)
+                            assert isinstance(value, str)
                             if value not in ALLOWED_LINK_VALUES:
                                 raise ParseException(
                                     f"Unknown value `{value}` for for key {key}.link."

--- a/bapctools/interactive.py
+++ b/bapctools/interactive.py
@@ -271,7 +271,7 @@ def run_interactive_testcase(
     with (
         interaction.open("a")
         if isinstance(interaction, Path)
-        else nullcontext(None) as interaction_file
+        else nullcontext(None) as interaction_file  # type: ignore[attr-defined]
     ):
         # Connect pipes with tee.
         TEE_CODE = R"""
@@ -366,7 +366,10 @@ while True:
                             validation_time - timeout
                         ):
                             return
-                        os.killpg(gid, signal.SIGKILL)
+                        try:
+                            os.killpg(gid, signal.SIGKILL)
+                        except (ProcessLookupError, PermissionError):
+                            pass
 
                     kill_handler = threading.Thread(target=kill_handler_function, daemon=True)
                     kill_handler.start()
@@ -403,7 +406,10 @@ while True:
                             # Kill the team submission and everything else in case we already know it's WA.
                             if first_done and validator_status != config.RTV_AC:
                                 stop_kill_handler.set()
-                                os.killpg(gid, signal.SIGKILL)
+                                try:
+                                    os.killpg(gid, signal.SIGKILL)
+                                except (ProcessLookupError, PermissionError):
+                                    pass
                             first_done = False
                         elif pid == submission_pid:
                             if first is None:
@@ -433,7 +439,10 @@ while True:
 
                     stop_kill_handler.set()
                 except KeyboardInterrupt:
-                    os.killpg(gid, signal.SIGKILL)
+                    try:
+                        os.killpg(gid, signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError):
+                        pass
                     raise KeyboardInterrupt()
 
                 assert submission_time is not None

--- a/bapctools/parallel.py
+++ b/bapctools/parallel.py
@@ -84,8 +84,8 @@ class SequentialQueue(AbstractQueue[T]):
     # Execute all tasks.
     def done(self) -> None:
         if self.pin:
-            cores = list(os.sched_getaffinity(0))
-            os.sched_setaffinity(0, {cores[0]})
+            cores = list(os.sched_getaffinity(0))  # type: ignore[attr-defined]
+            os.sched_setaffinity(0, {cores[0]})  # type: ignore[attr-defined]
 
         # no task will be handled after self.abort()
         while self.tasks and not self.aborted:
@@ -96,7 +96,7 @@ class SequentialQueue(AbstractQueue[T]):
                     raise e
 
         if self.pin:
-            os.sched_setaffinity(0, cores)
+            os.sched_setaffinity(0, cores)  # type: ignore[attr-defined]
 
 
 class ParallelQueue(AbstractQueue[T]):
@@ -116,7 +116,7 @@ class ParallelQueue(AbstractQueue[T]):
 
         if self.pin:
             # only use available cores and reserve one
-            cores = list(os.sched_getaffinity(0))
+            cores = list(os.sched_getaffinity(0))  # type: ignore[attr-defined]
             if self.num_threads > len(cores) - 1:
                 self.num_threads = len(cores) - 1
 
@@ -133,7 +133,7 @@ class ParallelQueue(AbstractQueue[T]):
 
     def _worker(self, cores: Literal[False] | list[int] = False) -> None:
         if cores is not False:
-            os.sched_setaffinity(0, cores)
+            os.sched_setaffinity(0, cores)  # type: ignore[attr-defined]
         while True:
             with self.mutex:
                 # if self.aborted we need no item in the queue and can stop

--- a/bapctools/resources/config/languages.yaml
+++ b/bapctools/resources/config/languages.yaml
@@ -171,7 +171,7 @@ java:
     name: 'Java'
     priority: 850
     files: '*.java'
-    compile: 'javac -encoding UTF-8 -sourcepath {path} -d {path} {files}'
+    compile: 'javac -encoding UTF-8 -cp {path} -sourcepath {path} -d {path} {files}'
     run: 'java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xss64m -Xms{memlim}m -Xmx{memlim}m -cp {path} {mainclass}'
 
 javascript:

--- a/bapctools/run.py
+++ b/bapctools/run.py
@@ -99,7 +99,7 @@ class Run:
             assert interaction is not True
             if interaction:
                 assert not interaction.is_relative_to(self.tmpdir)
-            with interaction.open("a") if interaction else nullcontext(None) as interaction_file:
+            with interaction.open("a") if interaction else nullcontext(None) as interaction_file:  # type: ignore[attr-defined]
                 nextpass = self.feedbackdir / "nextpass.in" if self.problem.multi_pass else None
                 pass_id = 0
                 max_duration = 0.0

--- a/bapctools/run.py
+++ b/bapctools/run.py
@@ -234,7 +234,7 @@ class Run:
             return False
         # clear all files outside of feedbackdir
         for f in self.tmpdir.iterdir():
-            if f == self.feedbackdir:
+            if f.resolve() == self.feedbackdir.resolve():
                 continue
             remove_path(f)
         # use nextpass.in as next input

--- a/bapctools/util.py
+++ b/bapctools/util.py
@@ -1060,9 +1060,7 @@ def remove_path(path: Path) -> None:
     try:
         try:
             path.unlink()
-        except IsADirectoryError:
-            shutil.rmtree(path)
-        except PermissionError:
+        except OSError:
             if path.is_dir():
                 shutil.rmtree(path)
             else:

--- a/bapctools/util.py
+++ b/bapctools/util.py
@@ -862,7 +862,7 @@ def ryaml_get_or_add(
         yaml[key] = t()
     value = yaml[key]
     assert isinstance(value, t)
-    return value
+    return value  # type: ignore[no-any-return]
 
 
 # This tries to preserve the correct comments.
@@ -1402,7 +1402,7 @@ def limit_setter(
             os.setpgid(0, group)
 
         if cores is not False:
-            os.sched_setaffinity(0, cores)
+            os.sched_setaffinity(0, cores)  # type: ignore[attr-defined]
 
         # Disable coredumps.
         resource.setrlimit(resource.RLIMIT_CORE, (0, 0))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,10 @@ check_untyped_defs = true
 enable_error_code="truthy-bool,truthy-iterable"
 strict = true
 mypy_path = ["third_party/stubs/"]
+
+[[tool.mypy.overrides]]
+# These files contain platform-specific type: ignore comments (macOS/Linux
+# differ on sched_*, nullcontext typing, and return type inference) that are
+# unused on the other platform. Suppress the resulting unused-ignore warnings.
+module = ["bapctools.parallel", "bapctools.util", "bapctools.interactive", "bapctools.run"]
+warn_unused_ignores = false

--- a/test/problems/alternativeencryption/output_validator/validate.h
+++ b/test/problems/alternativeencryption/output_validator/validate.h
@@ -10,6 +10,10 @@
 #ifndef VALIDATE_H
 #define VALIDATE_H
 
+#ifdef __APPLE__
+#define DOUBLE_FALLBACK
+#endif
+
 #include <algorithm>
 #include <array>
 #include <bitset>

--- a/test/test_problems.py
+++ b/test/test_problems.py
@@ -310,6 +310,7 @@ def tmp_contest_dir(tmp_path):
 @pytest.mark.usefixtures("tmp_contest_dir")
 class TestNewContestProblem:
     def test_new_contest_problem(self, monkeypatch):
+        monkeypatch.setattr("bapctools.util.has_questionary", False)
         monkeypatch.setattr("sys.stdin", io.StringIO("\n\n\n\n\n\n\n\n\n\n\n\n\n\n"))
         cli.test(["new_contest", "contest_name"])
         cli.test(


### PR DESCRIPTION
Five independent bugs, all exposed by running the full pytest suite on macOS on my own machine. (Pytest has never been all-green on my machine. Now it is. Claude-generated summary below:)

## Path identity under /var symlink (2 fixes)

macOS symlinks /var → /private/var. Path.__eq__ compares strings without resolving symlinks, so paths constructed from tempfile.gettempdir() (which returns /var/folders/…) didn't compare equal to paths returned by os.getcwd() or iterdir() (which return /private/var/folders/…).

- cli.py: apply .resolve() when constructing the tmpdir so all derived paths are canonical from the start.
- run.py (_prepare_nextpass): the feedbackdir comparison f == self.feedbackdir silently failed, causing the feedbackdir to be deleted between passes of multi-pass problems. Fixed with .resolve() on both sides.

## remove_path on non-empty directories (util.py)

On Linux, path.unlink() on a directory raises IsADirectoryError. On macOS it raises OSError(ENOTEMPTY) instead. Collapsed the exception handling to catch OSError broadly and check is_dir() before calling shutil.rmtree.

## javac inheriting user's CLASSPATH (languages.yaml)

javac without -cp inherits the environment's CLASSPATH. On a developer machine this can include unrelated jars (e.g. from a university course), causing Operation not permitted during compilation. Added -cp {path} to override it with just the tmpdir.

## questionary bypassing sys.stdin monkeypatch (test_problems.py)

questionary reads from the raw TTY file descriptor, not sys.stdin, so monkeypatching sys.stdin had no effect. Fixed by also patching bapctools.util.has_questionary = False to force the plain input() fallback path.

## Platform-specific type: ignore comments (pyproject.toml)

sched_getaffinity/sched_setaffinity exist in Linux's typeshed but not macOS's, so # type: ignore[attr-defined] comments needed on macOS are flagged as ed per-file warn_unused_ignores = falseoverrides for the four affected modules.

## from_chars for long double on macOS (validate.h)

Apple's libc++ implements std::from_chars for float and double but not long double. The upstream icpc-header already had a DOUBLE_FALLBACK (stold) foh #ifdef __APPLE__.