### PR TITLE
fix: copy validation.h content instead of broken symlink in new_problem

### DIFF
--- a/bapctools/util.py
+++ b/bapctools/util.py
@@ -1204,7 +1204,7 @@ def copytree_and_substitute(
         pass
     elif preserve_symlinks and os.path.islink(src):
         shutil.copy(src, dst, follow_symlinks=False)
-    elif os.path.islink(src) and src.absolute().is_relative_to(base.absolute()):
+    elif os.path.islink(src) and src.resolve().is_relative_to(base.absolute()):
         shutil.copy(src, dst, follow_symlinks=False)
     elif os.path.isdir(src):
         names = os.listdir(src)


### PR DESCRIPTION
copytree_and_substitute checked whether the symlink *file* was inside the skel base (always true), instead of checking where the symlink *points*. The validation.h symlinks in the built-in skel point to `../../../../headers/validation.h`, which is valid inside the skel tree but broken once copied to a new problem directory.

Changing src.absolute() → src.resolve() checks the resolved target path, so out-of-skel symlinks fall through to the normal file-copy path.